### PR TITLE
Specify `command rm` to bypass any aliases

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -2114,7 +2114,7 @@ _p9k_init_timer() {
     _P9K_TIMER_FD2=0
     unset -f _p9k_on_timer
   fi
-  rm -f "$fifo1" "$fifo2"
+  command rm -f "$fifo1" "$fifo2"
 }
 
 _p9k_init() {


### PR DESCRIPTION
I use [`careful_rm`](https://github.com/MikeDacre/careful_rm) which wraps `rm`.  There appears to be an issue with `careful_rm` that causes it to issue a warning when deleting the fifos, even though the `-f` switch is set.  I know the issue isn't related to powerlevel10k, but using `command rm` seems like a safe solution that may help others who have `rm` aliased.