### PR TITLE
add node_version only inside project folder option

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1171,11 +1171,35 @@ prompt_load() {
 
 ################################################################
 # Segment to diplay Node version
+set_default P9K_NODE_VERSION_PROJECT_ONLY false
 prompt_node_version() {
-  local node_version=$(node -v 2>/dev/null)
-  [[ -z "${node_version}" ]] && return
+  if [ "$P9K_NODE_VERSION_PROJECT_ONLY" = true ] ; then
+    local foundProject=false # Variable to stop searching if a project is found
+    local currentDir=$(pwd)  # Variable to iterate through the path ancestry tree
+    
+    # Search as long as no project could been found or until the root directory 
+    # has been reached
+    while [ "$foundProject" = false -a ! "$currentDir" = "/" ] ; do
 
-  "$1_prompt_segment" "$0" "$2" "green" "white" 'NODE_ICON' 0 '' "${${node_version:1}//\%/%%}"
+      # Check if directory contains a project description
+      if [[ -e "$currentDir/package.json" ]] ; then
+        foundProject=true
+        break
+      fi
+      # Go to the parent directory
+      currentDir="$(dirname "$currentDir")"
+    done
+  fi
+
+  # Show version if a project has been found, or set to always show
+  if [ "$P9K_NODE_VERSION_PROJECT_ONLY" != true -o "$foundProject" = true ] ; then
+    # Get the node version
+    local node_version=$(node -v 2>/dev/null)
+
+    # Return if node is not installed
+    [[ -z "${node_version}" ]] && return
+    "$1_prompt_segment" "$0" "$2" "green" "white" 'NODE_ICON' 0 '' "${${node_version:1}//\%/%%}"
+  fi
 }
 
 ################################################################


### PR DESCRIPTION
adding option for node status to be in project only
all the thanks goes to @weilbith, @ChrisBaker97 and the original PR [#1219](https://github.com/bhilburn/powerlevel9k/pull/1219) 

i am just take the code and change it to work with powerlevel10k as i am using node_version but its slow and i don't know how to enhance it and make it faster, and i would be more than glad if someone would help me to do so, so for now i will stick with node only in project folder as a reminder as i am using different version of node and i might use wrong version by mistake.
