### PR TITLE
Obey GIT_DIR if set for vcsh compatability

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1648,7 +1648,7 @@ function _p9k_vcs_style() {
 function _p9k_vcs_render() {
   if [[ -v _P9K_NEXT_VCS_DIR ]]; then
     local -a msg
-    local dir=${GIT_DIR:-$PWD}
+    local dir=${${GIT_DIR:a}:-$PWD}
     while true; do
       msg=("${(@0)${_P9K_LAST_GIT_PROMPT[$dir]}}")
       [[ $#msg != 0 || $dir == / ]] && break
@@ -1832,9 +1832,9 @@ function _p9k_vcs_gitstatus() {
   [[ $POWERLEVEL9K_DISABLE_GITSTATUS == true ]] && return 1
   if [[ $_P9K_REFRESH_REASON == precmd ]]; then
     if [[ -v _P9K_NEXT_VCS_DIR ]]; then
-      typeset -gH _P9K_NEXT_VCS_DIR=${GIT_DIR:-$PWD}
+      typeset -gH _P9K_NEXT_VCS_DIR=${${GIT_DIR:a}:-$PWD}
     else
-      local dir=${GIT_DIR:-$PWD}
+      local dir=${${GIT_DIR:a}:-$PWD}
       local -F timeout=$POWERLEVEL9K_VCS_MAX_SYNC_LATENCY_SECONDS
       while true; do
         case "$_P9K_GIT_SLOW[$dir]" in
@@ -1844,7 +1844,7 @@ function _p9k_vcs_gitstatus() {
         esac
       done
       typeset -gFH _P9K_GITSTATUS_START_TIME=$EPOCHREALTIME
-      gitstatus_query -d ${GIT_DIR:-$PWD} -t $timeout -c _p9k_vcs_resume POWERLEVEL9K || return 1
+      gitstatus_query -d ${${GIT_DIR:a}:-$PWD} -t $timeout -c _p9k_vcs_resume POWERLEVEL9K || return 1
       [[ $VCS_STATUS_RESULT == tout ]] && typeset -gH _P9K_NEXT_VCS_DIR=""
     fi
   fi

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1648,7 +1648,7 @@ function _p9k_vcs_style() {
 function _p9k_vcs_render() {
   if [[ -v _P9K_NEXT_VCS_DIR ]]; then
     local -a msg
-    local dir=$PWD
+    local dir=${GIT_DIR:-$PWD}
     while true; do
       msg=("${(@0)${_P9K_LAST_GIT_PROMPT[$dir]}}")
       [[ $#msg != 0 || $dir == / ]] && break
@@ -1832,9 +1832,9 @@ function _p9k_vcs_gitstatus() {
   [[ $POWERLEVEL9K_DISABLE_GITSTATUS == true ]] && return 1
   if [[ $_P9K_REFRESH_REASON == precmd ]]; then
     if [[ -v _P9K_NEXT_VCS_DIR ]]; then
-      typeset -gH _P9K_NEXT_VCS_DIR=$PWD
+      typeset -gH _P9K_NEXT_VCS_DIR=${GIT_DIR:-$PWD}
     else
-      local dir=$PWD
+      local dir=${GIT_DIR:-$PWD}
       local -F timeout=$POWERLEVEL9K_VCS_MAX_SYNC_LATENCY_SECONDS
       while true; do
         case "$_P9K_GIT_SLOW[$dir]" in
@@ -1844,7 +1844,7 @@ function _p9k_vcs_gitstatus() {
         esac
       done
       typeset -gFH _P9K_GITSTATUS_START_TIME=$EPOCHREALTIME
-      gitstatus_query -t $timeout -c _p9k_vcs_resume POWERLEVEL9K || return 1
+      gitstatus_query -d ${GIT_DIR:-$PWD} -t $timeout -c _p9k_vcs_resume POWERLEVEL9K || return 1
       [[ $VCS_STATUS_RESULT == tout ]] && typeset -gH _P9K_NEXT_VCS_DIR=""
     fi
   fi


### PR DESCRIPTION
I've had my eye on powerlevel9k for a long time but never been convinced to take the dive until the git status caching thing in this fork hit the news wires and gave me a compelling reason to mash my configs around. One of the first things I noticed when switching from my long time theme (a fork of Agnoster) to powerlevel10k was that it did not handle [VCSH](https://github.com/RichiH/vcsh) repositories properly. VCSH relies on keeping the git directory in a disconnected state (out of the current directory path). Git handles this quite gracefully though the use of the `GIT_DIR` variable, but `gitstatus` was ignoring this.

I'm not sure if this is the _best_ fix, perhaps it should be fixed in `gitstatus` instead, but this fix at least got me up and running. If there is a better place to fix it let me know and I'd be happy to make the contribution.