### PR TITLE
Add VCS_LOADING_ICON to the icons map (fixes #46)

### DIFF
--- a/functions/icons.zsh
+++ b/functions/icons.zsh
@@ -96,6 +96,7 @@ function _p9k_init_icons() {
         VCS_COMMIT_ICON                $'\uE821 '             # 
         VCS_BRANCH_ICON                $'\uE220 '             # 
         VCS_REMOTE_BRANCH_ICON         $'\u2192'              # →
+        VCS_LOADING_ICON               ''
         VCS_GIT_ICON                   $'\uE20E '             # 
         VCS_GIT_GITHUB_ICON            $'\uE20E '             #
         VCS_GIT_BITBUCKET_ICON         $'\uE20E '             #
@@ -192,6 +193,7 @@ function _p9k_init_icons() {
         VCS_COMMIT_ICON                $'\uF221 '             # 
         VCS_BRANCH_ICON                $'\uF126 '             # 
         VCS_REMOTE_BRANCH_ICON         $'\u2192'              # →
+        VCS_LOADING_ICON               ''
         VCS_GIT_ICON                   $'\uF1D3 '             # 
         VCS_GIT_GITHUB_ICON            $'\uF113 '             # 
         VCS_GIT_BITBUCKET_ICON         $'\uF171 '             # 
@@ -294,6 +296,7 @@ function _p9k_init_icons() {
         VCS_COMMIT_ICON                '\u'$CODEPOINT_OF_OCTICONS_GIT_COMMIT' '       # 
         VCS_BRANCH_ICON                '\u'$CODEPOINT_OF_OCTICONS_GIT_BRANCH' '       # 
         VCS_REMOTE_BRANCH_ICON         '\u'$CODEPOINT_OF_OCTICONS_REPO_PUSH           # 
+        VCS_LOADING_ICON               ''
         VCS_GIT_ICON                   '\u'$CODEPOINT_OF_AWESOME_GIT' '               # 
         VCS_GIT_GITHUB_ICON            '\u'$CODEPOINT_OF_AWESOME_GITHUB_ALT' '        # 
         VCS_GIT_BITBUCKET_ICON         '\u'$CODEPOINT_OF_AWESOME_BITBUCKET' '         # 
@@ -390,6 +393,7 @@ function _p9k_init_icons() {
         VCS_COMMIT_ICON                $'\uE729 '             # 
         VCS_BRANCH_ICON                $'\uF126 '             # 
         VCS_REMOTE_BRANCH_ICON         $'\uE728 '             # 
+        VCS_LOADING_ICON               ''
         VCS_GIT_ICON                   $'\uF1D3 '             # 
         VCS_GIT_GITHUB_ICON            $'\uF113 '             # 
         VCS_GIT_BITBUCKET_ICON         $'\uE703 '             # 
@@ -486,6 +490,7 @@ function _p9k_init_icons() {
         VCS_COMMIT_ICON                ''
         VCS_BRANCH_ICON                $'\uE0A0 '             # 
         VCS_REMOTE_BRANCH_ICON         $'\u2192'              # →
+        VCS_LOADING_ICON               ''
         VCS_GIT_ICON                   ''
         VCS_GIT_GITHUB_ICON            ''
         VCS_GIT_BITBUCKET_ICON         ''

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -111,7 +111,7 @@ set_default -i POWERLEVEL9K_MAX_CACHE_SIZE 10000
 #     _p9k_cache_set "$val1" "$val2"
 #   fi
 #   # Here ${_P9K_CACHE_VAL[1]} and ${_P9K_CACHE_VAL[2]} are $val1 and $val2 respectively.
-# 
+#
 # Limitations:
 #
 #   * Calling _p9k_cache_set without arguments clears the cache entry. Subsequent calls to
@@ -242,7 +242,7 @@ left_prompt_segment() {
     pre+="\${\${_P9K_N:=\${\${\$((!\${#\${:-0\$_P9K_BG}:#0$bg_color})):#0}:+$((t+3))}}+}"  # 3
     pre+="\${\${_P9K_N:=\${\${_P9K_F::=%F{\$_P9K_BG\}}+$((t+4))}}+}"                       # 4
     pre+="\$_P9K_F\${_P9K_T[\$_P9K_N]}"
-    
+
     local post="\${_P9K_C}$space\${\${_P9K_I::=$2}+}\${\${_P9K_BG::=$bg_color}+}}"
 
     _p9k_cache_set $has_icon $fg $pre $post
@@ -295,7 +295,7 @@ right_prompt_segment() {
         has_icon=1
       fi
     fi
-    
+
     # Segment separator logic is the same as in left_prompt_segment except that here #4 and #1 are
     # identical.
 
@@ -317,7 +317,7 @@ right_prompt_segment() {
     pre+="\${\${_P9K_N:=\${\${\$((!\${#\${:-0\$_P9K_BG}:#0$bg_color})):#0}:+$((t+3))}}+}"  # 3
     pre+="\${\${_P9K_N:=$((t+1))}+}"                                                       # 4 == 1
     pre+="\${_P9K_T[\$_P9K_N]}\${_P9K_C}$icon_fg"
-    
+
     _p9k_escape_rcurly $POWERLEVEL9K_WHITESPACE_BETWEEN_RIGHT_SEGMENTS
     local post="$icon$_P9K_RETVAL\${\${_P9K_I::=$2}+}\${\${_P9K_BG::=$bg_color}+}}"
 
@@ -1205,8 +1205,8 @@ prompt_node_version() {
   if [ "$P9K_NODE_VERSION_PROJECT_ONLY" = true ] ; then
     local foundProject=false # Variable to stop searching if a project is found
     local currentDir=$(pwd)  # Variable to iterate through the path ancestry tree
-    
-    # Search as long as no project could been found or until the root directory 
+
+    # Search as long as no project could been found or until the root directory
     # has been reached
     while [ "$foundProject" = false -a ! "$currentDir" = "/" ] ; do
 
@@ -1442,7 +1442,7 @@ prompt_status() {
       if (( $#_P9K_PIPE_EXIT_CODES > 1 )); then
         ec_sum=${_P9K_PIPE_EXIT_CODES[1]}
         exit_code_or_status "${_P9K_PIPE_EXIT_CODES[1]}"
-        
+
       else
         ec_sum=${_P9K_EXIT_CODE}
         exit_code_or_status "${_P9K_EXIT_CODE}"
@@ -1686,7 +1686,7 @@ function _p9k_vcs_render() {
     if [[ $#msg -lt 2 && -z ${msg[1]} ]]; then
       _p9k_get_icon VCS_LOADING_ICON
       if [[ -n $_P9K_RETVAL || -n $POWERLEVEL9K_VCS_LOADING_TEXT ]]; then
-        $2_prompt_segment $1_LOADING $3 "${vcs_states[loading]}" "$DEFAULT_COLOR" "$_P9K_RETVAL" 0 '' "$POWERLEVEL9K_VCS_LOADING_TEXT"
+        $2_prompt_segment $1_LOADING $3 "${vcs_states[loading]}" "$DEFAULT_COLOR" VCS_LOADING_ICON 0 '' "$POWERLEVEL9K_VCS_LOADING_TEXT"
       fi
     else
       $2_prompt_segment $1_LOADING $3 "${vcs_states[loading]}" "$DEFAULT_COLOR" '' 0 '' "${msg[@]}"


### PR DESCRIPTION
It seems that the VCS_LOADING_ICON wasn't working (#46) because it was trying to load the icon from the icons map, but this icon was never added to the icons map. So this pr just adds it to the icon map (with no value) and the uses the key name for the icon map as required by `left_prompt_segment`.