### PR TITLE
Fix weird parser error

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -2402,7 +2402,7 @@ _p9k_init() {
   fi
 
   # If the terminal `LANG` is set to `C`, this theme will not work at all.
-  if [[ $LANG == C && $POWERLEVEL9K_IGNORE_TERM_LANG == false ]]; then
+  if [[ $LANG == "C" && $POWERLEVEL9K_IGNORE_TERM_LANG == false ]]; then
     print -P "\t%F{red}WARNING!%f Your terminal's 'LANG' is set to 'C', which breaks this theme!"
     print -P "\t%F{red}WARNING!%f Please set your 'LANG' to a UTF-8 language, like 'en_US.UTF-8'"
     print -P "\t%F{red}WARNING!%f _before_ loading this theme in your \~\.zshrc. Putting"


### PR DESCRIPTION
If the C is left unquoted, it will result in `$ANTIGEN_PATH/bundles/romkatv/powerlevel10k/powerlevel9k.zsh-theme.antigen-compat:133: parse error: condition expected: $LANG` or something along those lines with a recent zsh version. This fixes that issue.