### PR TITLE
battery segment for symlinkers

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -494,7 +494,7 @@ prompt_battery() {
     ;;
 
     Linux|Android)
-      local -a bats=( /sys/class/power_supply/(BAT*|battery)(FN) )
+      local -a bats=( /sys/class/power_supply/(BAT*|battery)/(FN) )
       (( $#bats )) || return
 
       local -i energy_now energy_full power_now 


### PR DESCRIPTION
`(F)` does not recognize symlinks as dirs if you don't use the trailing `/`

```zsh
❯ ls -ld /sys/class/power_supply/BAT*
lrwxrwxrwx 1 root root 0 May 23 22:12 /sys/class/power_supply/BAT0 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:19/PNP0C09:00/PNP0C0A:00/power_supply/BAT0
lrwxrwxrwx 1 root root 0 May 23 22:12 /sys/class/power_supply/BAT1 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:19/PNP0C09:00/PNP0C0A:01/power_supply/BAT1

```