### PR TITLE
Fixes multiple truncate_to_unique inconsistencies/bugs

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -835,8 +835,9 @@ prompt_dir() {
       fi
     ;;
     truncate_to_unique)
-      local -i i=2 n=1
+      local -i i=2 n=1 d=0
       delim=${POWERLEVEL9K_SHORTEN_DELIMITER-'*'}
+      d=${POWERLEVEL9K_SHORTEN_DELIMITER_LENGTH:-$#POWERLEVEL9K_SHORTEN_DELIMITER}
       (( POWERLEVEL9K_SHORTEN_DIR_LENGTH >= 0 )) && n=POWERLEVEL9K_SHORTEN_DIR_LENGTH
       local pat=${POWERLEVEL9K_SHORTEN_FOLDER_MARKER-'(.bzr|CVS|.git|.hg|.svn|.citc)'}
       local parent="${PWD%/${(pj./.)parts[i,-1]}}"
@@ -850,11 +851,11 @@ prompt_dir() {
           fi
         fi
         local -i j=1
-        for (( ; j + $#delim < $#dir; ++j )); do
+        for (( ; j + d < $#dir; ++j )); do
           local -a matching=($parent/$dir[1,j]*/(N))
           (( $#matching == 1 )) && break
         done
-        (( j + $#delim >= $#dir )) || parts[i]=$dir[1,j]$'\0'
+        (( j + d >= $#dir )) || parts[i]=$dir[1,j]$'\0'
         parent+=/$dir
       done
     ;;

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -836,6 +836,7 @@ prompt_dir() {
     ;;
     truncate_to_unique)
       local -i i=2 n=1 d=0
+      [[ $p == /* ]] && (( ++i ))
       delim=${POWERLEVEL9K_SHORTEN_DELIMITER-'*'}
       shortenlen=${POWERLEVEL9K_SHORTEN_DIR_LENGTH:-1}
       d=${POWERLEVEL9K_SHORTEN_DELIMITER_LENGTH:-$#POWERLEVEL9K_SHORTEN_DELIMITER}

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -836,8 +836,8 @@ prompt_dir() {
     ;;
     truncate_to_unique)
       local -i i=2 n=1
-      [[ $p == /* ]] && (( ++i ))
-      (( POWERLEVEL9K_SHORTEN_DIR_LENGTH > 0 )) && n=POWERLEVEL9K_SHORTEN_DIR_LENGTH
+      delim=${POWERLEVEL9K_SHORTEN_DELIMITER-'*'}
+      (( POWERLEVEL9K_SHORTEN_DIR_LENGTH >= 0 )) && n=POWERLEVEL9K_SHORTEN_DIR_LENGTH
       local pat=${POWERLEVEL9K_SHORTEN_FOLDER_MARKER-'(.bzr|CVS|.git|.hg|.svn|.citc)'}
       local parent="${PWD%/${(pj./.)parts[i,-1]}}"
       for (( ; i <= $#parts - n; ++i )); do
@@ -850,14 +850,13 @@ prompt_dir() {
           fi
         fi
         local -i j=1
-        for (( ; j < $#dir; ++j )); do
+        for (( ; j + $#delim < $#dir; ++j )); do
           local -a matching=($parent/$dir[1,j]*/(N))
           (( $#matching == 1 )) && break
         done
-        (( j == $#dir )) || parts[i]=$dir[1,j]$'\0'
+        (( j + $#delim >= $#dir )) || parts[i]=$dir[1,j]$'\0'
         parent+=/$dir
       done
-      delim=${POWERLEVEL9K_SHORTEN_DELIMITER-'*'}
     ;;
     truncate_with_folder_marker)
       local pat=${POWERLEVEL9K_SHORTEN_FOLDER_MARKER-.shorten_folder_marker}

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -767,13 +767,14 @@ prompt_dir() {
     local -a parts=("${(s:/:)p}")
   fi
 
-  local -i fake_first=0 shortenlen
+  local -i fake_first=0
   local delim=${POWERLEVEL9K_SHORTEN_DELIMITER-$'\u2026'}
-  local shortenlen=${POWERLEVEL9K_SHORTEN_DIR_LENGTH:--1}
+  local -i shortenlen=${POWERLEVEL9K_SHORTEN_DIR_LENGTH:--1}
+  local -i d=${POWERLEVEL9K_SHORTEN_DELIMITER_LENGTH:-$#POWERLEVEL9K_SHORTEN_DELIMITER}
 
   case $POWERLEVEL9K_SHORTEN_STRATEGY in
     truncate_absolute|truncate_absolute_chars)
-      if (( shortenlen > 0 && $#p > shortenlen + 1 )); then
+      if (( shortenlen > 0 && $#p > shortenlen + d )); then
         local -i n=shortenlen
         local -i i=$#parts
         while true; do
@@ -814,7 +815,7 @@ prompt_dir() {
         [[ $POWERLEVEL9K_SHORTEN_STRATEGY == truncate_middle ]] && suf=pref
         for (( ; i < $#parts; ++i )); do
           local dir=$parts[i]
-          if (( $#dir > pref + suf + 1 )); then
+          if (( $#dir > pref + suf + d )); then
             dir[pref+1,-suf-1]=$'\0'
             parts[i]=$dir
           fi
@@ -835,11 +836,10 @@ prompt_dir() {
       fi
     ;;
     truncate_to_unique)
-      local -i i=2 n=1 d=0
+      local -i i=2 n=1
       [[ $p == /* ]] && (( ++i ))
       delim=${POWERLEVEL9K_SHORTEN_DELIMITER-'*'}
       shortenlen=${POWERLEVEL9K_SHORTEN_DIR_LENGTH:-1}
-      d=${POWERLEVEL9K_SHORTEN_DELIMITER_LENGTH:-$#POWERLEVEL9K_SHORTEN_DELIMITER}
       (( shortenlen >= 0 )) && n=shortenlen
       local pat=${POWERLEVEL9K_SHORTEN_FOLDER_MARKER-'(.bzr|CVS|.git|.hg|.svn|.citc)'}
       local parent="${PWD%/${(pj./.)parts[i,-1]}}"

--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -735,7 +735,6 @@ set_default POWERLEVEL9K_DIR_SHOW_WRITABLE false
 set_default POWERLEVEL9K_DIR_OMIT_FIRST_CHARACTER false
 set_default POWERLEVEL9K_SHORTEN_STRATEGY ""
 set_default POWERLEVEL9K_DIR_PATH_SEPARATOR_FOREGROUND ""
-set_default -i POWERLEVEL9K_SHORTEN_DIR_LENGTH -1
 # Individual elements are patterns. They are expanded with the options set by `emulate zsh`.
 set_default -a POWERLEVEL9K_DIR_PACKAGE_FILES package.json composer.json
 
@@ -768,13 +767,14 @@ prompt_dir() {
     local -a parts=("${(s:/:)p}")
   fi
 
-  local -i fake_first=0
+  local -i fake_first=0 shortenlen
   local delim=${POWERLEVEL9K_SHORTEN_DELIMITER-$'\u2026'}
+  local shortenlen=${POWERLEVEL9K_SHORTEN_DIR_LENGTH:--1}
 
   case $POWERLEVEL9K_SHORTEN_STRATEGY in
     truncate_absolute|truncate_absolute_chars)
-      if (( POWERLEVEL9K_SHORTEN_DIR_LENGTH > 0 && $#p > POWERLEVEL9K_SHORTEN_DIR_LENGTH + 1 )); then
-        local -i n=POWERLEVEL9K_SHORTEN_DIR_LENGTH
+      if (( shortenlen > 0 && $#p > shortenlen + 1 )); then
+        local -i n=shortenlen
         local -i i=$#parts
         while true; do
           local dir=$parts[i]
@@ -809,8 +809,8 @@ prompt_dir() {
           dir=${dir:h}
         done
       }
-      if (( POWERLEVEL9K_SHORTEN_DIR_LENGTH > 0 )); then
-        local -i pref=$POWERLEVEL9K_SHORTEN_DIR_LENGTH suf=0 i=2
+      if (( shortenlen > 0 )); then
+        local -i pref=$shortenlen suf=0 i=2
         [[ $POWERLEVEL9K_SHORTEN_STRATEGY == truncate_middle ]] && suf=pref
         for (( ; i < $#parts; ++i )); do
           local dir=$parts[i]
@@ -826,10 +826,10 @@ prompt_dir() {
       parts[1,-2]=()
     ;;
     truncate_to_first_and_last)
-      if (( POWERLEVEL9K_SHORTEN_DIR_LENGTH > 0 )); then
-        local -i i=$(( POWERLEVEL9K_SHORTEN_DIR_LENGTH + 1 ))
+      if (( shortenlen > 0 )); then
+        local -i i=$(( shortenlen + 1 ))
         [[ $p == /* ]] && (( ++i ))
-        for (( ; i <= $#parts - POWERLEVEL9K_SHORTEN_DIR_LENGTH; ++i )); do
+        for (( ; i <= $#parts - shortenlen; ++i )); do
           parts[i]=$'\0'
         done
       fi
@@ -837,8 +837,9 @@ prompt_dir() {
     truncate_to_unique)
       local -i i=2 n=1 d=0
       delim=${POWERLEVEL9K_SHORTEN_DELIMITER-'*'}
+      shortenlen=${POWERLEVEL9K_SHORTEN_DIR_LENGTH:-1}
       d=${POWERLEVEL9K_SHORTEN_DELIMITER_LENGTH:-$#POWERLEVEL9K_SHORTEN_DELIMITER}
-      (( POWERLEVEL9K_SHORTEN_DIR_LENGTH >= 0 )) && n=POWERLEVEL9K_SHORTEN_DIR_LENGTH
+      (( shortenlen >= 0 )) && n=shortenlen
       local pat=${POWERLEVEL9K_SHORTEN_FOLDER_MARKER-'(.bzr|CVS|.git|.hg|.svn|.citc)'}
       local parent="${PWD%/${(pj./.)parts[i,-1]}}"
       for (( ; i <= $#parts - n; ++i )); do
@@ -877,11 +878,11 @@ prompt_dir() {
       fi
     ;;
     *)
-      if (( POWERLEVEL9K_SHORTEN_DIR_LENGTH > 0 )); then
+      if (( shortenlen > 0 )); then
         local -i len=$#parts
         [[ -z $parts[1] ]] && (( --len ))
-        if (( len > POWERLEVEL9K_SHORTEN_DIR_LENGTH )); then
-          parts[1,-POWERLEVEL9K_SHORTEN_DIR_LENGTH-1]=($'\0')
+        if (( len > shortenlen )); then
+          parts[1,-shortenlen-1]=($'\0')
         fi
       fi
     ;;


### PR DESCRIPTION
I think I found three bugs and tried to squash them:
1. first dir is not truncated. This might be on purpose, and might come down to personal preference. I don't see the appeal tbh. I imagine you could "protect" it manually by playing a `POWERLEVEL9K_SHORTEN_FOLDER_MARKER` in `/`
2. length of `POWERLEVEL9K_SHORTEN_DELIMITER` is not taken into account. Example: Why would I "shorten" `123` to `12*` or even `12345` to `1234..`)
3. last dir is not truncated even though `POWERLEVEL9K_SHORTEN_DIR_LENGTH=0`

![image](https://user-images.githubusercontent.com/16988672/58372087-f05bc700-7f18-11e9-9125-085ecfb69763.png)

```zsh
docker run -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 -e TERM=$TERM -it --rm ubuntu bash -uexc '
  cd
  apt update && apt install -y zsh git vim
  git clone https://github.com/romkatv/powerlevel10k.git
  echo "
    POWERLEVEL9K_SHORTEN_STRATEGY=truncate_to_unique
    POWERLEVEL9K_SHORTEN_DELIMITER='\''*'\''
    POWERLEVEL9K_SHORTEN_DIR_LENGTH=0
    mkdir -p /tmp/1{,23}/bla
    cd /tmp/123/bla
    source ~/powerlevel10k/powerlevel10k.zsh-theme" >~/.zshrc
  exec zsh'
```