### PR TITLE
Fixes illegal option message from uname on macOs

### DIFF
--- a/gitstatus/gitstatus.plugin.zsh
+++ b/gitstatus/gitstatus.plugin.zsh
@@ -274,8 +274,10 @@ function gitstatus_start() {
       exec {stderr_fd}>&2 2>$xtrace_file
       setopt xtrace
     }
-
-    local os && { [[ $(uname -o) == Android ]] && os=Android || os=$(uname -s) } && [[ -n $os ]]
+    
+    # uname -o fails on macOS, so suppress it's stderr output as that case
+    # will be caught by uname -s
+    local os && { [[ $(uname -o 2>/dev/null) == Android ]] && os=Android || os=$(uname -s) } && [[ -n $os ]]
     local arch && arch=$(uname -m) && [[ -n $arch ]]
 
     local daemon=${GITSTATUS_DAEMON:-$dir/bin/gitstatusd-${os:l}-${arch:l}}


### PR DESCRIPTION
On my Macbook, powerlevel10k starts with the following message:

```
Last login: Thu Jun  6 11:42:53 on ttys000
uname: illegal option -- o
usage: uname [-amnprsv]
```

This is because `uname -o` is used in gitstatus/gitstatus.plugin.zsh. The `-o`switch is not supported on macOs.

This PR suppresses the stderr output of the offending command, as the macOs case is handled later in the expression with the `uname -s` command.