### PR TITLE
Add space between remote icon and commit hash

### DIFF
--- a/functions/vcs.zsh
+++ b/functions/vcs.zsh
@@ -141,6 +141,8 @@ function +vi-vcs-detect-changes() {
     vcs_visual_identifier='VCS_SVN_ICON'
   fi
 
+  [[ -n "$vcs_visual_identifier" ]] && vcs_visual_identifier="$vcs_visual_identifier "
+
   if [[ -n "${hook_com[staged]}" ]] || [[ -n "${hook_com[unstaged]}" ]]; then
     VCS_WORKDIR_DIRTY=true
   else

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -1791,21 +1791,18 @@ function _p9k_vcs_render() {
       # of the GIT icon. That's what vcs_info does, so we do the same in the name of compatiblity.
       if [[ "$VCS_STATUS_REMOTE_URL" == *github* ]] then
         _p9k_get_icon VCS_GIT_GITHUB_ICON
-        _$0_fmt REMOTE_URL $_P9K_RETVAL
       elif [[ "$VCS_STATUS_REMOTE_URL" == *bitbucket* ]] then
         _p9k_get_icon VCS_GIT_BITBUCKET_ICON
-        _$0_fmt REMOTE_URL $_P9K_RETVAL
       elif [[ "$VCS_STATUS_REMOTE_URL" == *stash* ]] then
         _p9k_get_icon VCS_GIT_GITHUB_ICON
-        _$0_fmt REMOTE_URL $_P9K_RETVAL
       elif [[ "$VCS_STATUS_REMOTE_URL" == *gitlab* ]] then
         _p9k_get_icon VCS_GIT_GITLAB_ICON
-        _$0_fmt REMOTE_URL $_P9K_RETVAL
       else
         _p9k_get_icon VCS_GIT_ICON
-        _$0_fmt REMOTE_URL $_P9K_RETVAL
       fi
     fi
+
+    _$0_fmt REMOTE_URL "$_P9K_RETVAL "
 
     local ws
     if [[ $POWERLEVEL9K_SHOW_CHANGESET == true || -z $VCS_STATUS_LOCAL_BRANCH ]]; then


### PR DESCRIPTION
There is an extra space between the remote vcs icon and the commit hash in Powerlevel9k that does not appears in Powerlevel10k

This is due to how Powerlevel10k get the icons from Powerlevel9k with `_p9k_get_icon` function

**powerlevel9k**
![powerlevel9k](https://user-images.githubusercontent.com/16347742/60567833-83371f00-9d6b-11e9-9556-8f7bd0450ac8.png)

**powerlvel10k**
![powerlevel10k](https://user-images.githubusercontent.com/16347742/60567844-8a5e2d00-9d6b-11e9-902a-662ee25f15a8.png)
