### PR TITLE
Add custom display function support for kubecontext segment

### DIFF
--- a/EXTENDED_CONFIGURATION.md
+++ b/EXTENDED_CONFIGURATION.md
@@ -43,6 +43,19 @@ another
 You can pick up a fix for the latter from
 [a fork of zsh](https://github.com/romkatv/zsh/tree/gentle-reset-prompt).
 
+`POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION (FUNCTION) [default=""]`
+
+Add your own function to modify the k8s context name, e.g. remove superfluous information:
+
+```bash
+# Input: gke_project-name-1337_europe-west1-c_production/ns
+# Output: production
+function k8s_context_short() {
+  echo "$1" | sed -E 's/.*-[a-z]_(.*)\/.*/\1/'
+}
+POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION="k8s_context_short"
+```
+
 When using gitstatus, there is an extra state called `LOADING` that is used by `vcs` prompt
 segment when it's waiting for git status in the background. You can define styling for this
 state the same way as for the other states -- `CLEAN`, `UNTRACKED` and `MODIFIED`. You can

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ budget for other plugins you might install.
 
 Powerlevel10k is released under the
 [MIT license](https://github.com/romkatv/powerlevel10k/blob/master/LICENSE). Contributions are
-convered by the same license.
+covered by the same license.
 
 ## FAQ
 

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -2126,6 +2126,9 @@ prompt_kubecontext() {
         fi
       done
     fi
+    if [[ -n $POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION ]]; then
+      ctx=$($POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION $ctx)
+    fi
     _p9k_cache_set "$ctx" "$suf"
   fi
 


### PR DESCRIPTION
Hi,

this PR adds the possibility to provide a function to modify the k8s context. When using the Google Kubernetes Engine this may be `gke_project-name-1337_europe-west1-c_production/ns` which takes up quite some space and the only interesting part is `production`.

```bash
# Input: gke_project-name-1337_europe-west1-c_production/ns
# Output: production
function k8s_context_short() {
  echo "$1" | sed -E 's/.*-[a-z]_(.*)\/.*/\1/'
}
POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION="k8s_context_short"
```

This PR is inspired from https://github.com/jonmosco/kube-ps1#customize-display-of-cluster-name-and-namespace. The difference here is that this function handles either only the context name or context/ns combination (depending on the default namespace setting). I wasn't sure if functions for both were really needed.

Do you think this would be a good fit here? I'm open for suggestions!

Thanks for 10k!