### PR TITLE
Revert "Add ability to provide a cluster function in kubecontext segment"

### DIFF
--- a/EXTENDED_CONFIGURATION.md
+++ b/EXTENDED_CONFIGURATION.md
@@ -43,19 +43,6 @@ another
 You can pick up a fix for the latter from
 [a fork of zsh](https://github.com/romkatv/zsh/tree/gentle-reset-prompt).
 
-`POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION (FUNCTION) [default=""]`
-
-Add your own function to modify the k8s context name, e.g. remove superfluous information:
-
-```bash
-# Input: gke_project-name-1337_europe-west1-c_production/ns
-# Output: production
-function k8s_context_short() {
-  echo "$1" | sed -E 's/.*-[a-z]_(.*)\/.*/\1/'
-}
-POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION="k8s_context_short"
-```
-
 When using gitstatus, there is an extra state called `LOADING` that is used by `vcs` prompt
 segment when it's waiting for git status in the background. You can define styling for this
 state the same way as for the other states -- `CLEAN`, `UNTRACKED` and `MODIFIED`. You can

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -2197,9 +2197,6 @@ prompt_kubecontext() {
         fi
       done
     fi
-    if [[ -n $POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION ]]; then
-      ctx=$($POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION $ctx)
-    fi
     _p9k_cache_set "$ctx" "$suf"
   fi
 


### PR DESCRIPTION
This reverts commit a9d99c9cab69bd52edd3584ea426d8dacd6e8929 (`POWERLEVEL9K_KUBECONTEXT_CONTEXT_FUNCTION`).

Only a74603d30f2e1fbbffc53346382ac280725a06c6 (the typo fix) was supposed to be merged in https://github.com/romkatv/powerlevel10k/pull/106. Sorry if it wasn't clear that this was still in the PR.

But everything's cleaned up now 👍 