### PR TITLE
Fix name of old windows terminal emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ applications on your system. Configure your terminal to use this font:
   `MesloLGS NF` under `module.exports.config`.
 - **Visual Studio Code**: Open *File → Preferences → Settings*, enter
   `terminal.integrated.fontFamily` in the search box and set value to `MesloLGS NF`.
-- **Windows Command Prompt** (the old thing): Click the icon in the top left corner, then
+- **Windows Console Host** (the old thing): Click the icon in the top left corner, then
   *Properties → Font* and set *Font* to `MesloLGS NF`.
 - **Windows Terminal** (the new thing): Open *Settings* (`Ctrl+,`), search for `fontFace` and set
   value to `MesloLGS NF` for every profile.


### PR DESCRIPTION
Command prompt is the shell, Console Host is the (equivalent) of xterm.