### PR TITLE
Add support for awsume

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -935,7 +935,7 @@ prompt_anaconda() {
 # AWS Profile
 prompt_aws() {
   local aws_profile="${AWS_VAULT:-${AWSUME_PROFILE:-${AWS_PROFILE:-$AWS_DEFAULT_PROFILE}}}"
-  if [[ "$aws_profile" != (default|) ]]; then
+  if [[ ! -z "$aws_profile" ]]; then
     _p9k_prompt_segment "$0" red white 'AWS_ICON' 0 '' "${aws_profile//\%/%%}"
   fi
 }

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -934,7 +934,7 @@ prompt_anaconda() {
 ################################################################
 # AWS Profile
 prompt_aws() {
-  local aws_profile="${AWS_VAULT:-${AWS_PROFILE:-$AWS_DEFAULT_PROFILE}}"
+  local aws_profile="${AWS_VAULT:-${AWSUME_PROFILE:-${AWS_PROFILE:-$AWS_DEFAULT_PROFILE}}}"
   if [[ "$aws_profile" != (default|) ]]; then
     _p9k_prompt_segment "$0" red white 'AWS_ICON' 0 '' "${aws_profile//\%/%%}"
   fi


### PR DESCRIPTION
We use `awsume` in our company to easily assume roles in multiple accounts.
This tool sets its own environment variable that shows which profile is active.
It is somewhat comparable to `aws-vault` which is already supported.