### PR TITLE
"Use built-in Powerline glyphs" in iTerm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Download these four ttf files:
 Double-click on each file and press "Install". This will make `MesloLGS NF` font available to all
 applications on your system. Configure your terminal to use this font:
 
-- **iTerm2**: Open *iTerm2 → Preferences → Profiles → Text* and set *Font* to `MesloLGS NF`.
+- **iTerm2**: Open *iTerm2 → Preferences → Profiles → Text* and set *Font* to `MesloLGS NF`.  Be
+  sure that *Use built-in Powerline glyphs* is checked under *Text Rendering*.
 - **Hyper**: Open *Hyper → Edit → Preferences* and change the value of `fontFamily` under
   `module.exports.config` to `MesloLGS NF`.
 - **Visual Studio Code**: Open *File → Preferences → Settings*, enter


### PR DESCRIPTION
To see the icons properly in iTerm2, *Use built-in Powerline glyphs* must be checked.

![image](https://user-images.githubusercontent.com/387006/67106824-55021180-f199-11e9-97a6-161bc7b7b54e.png)
![image](https://user-images.githubusercontent.com/387006/67106862-677c4b00-f199-11e9-91b4-ad17a71c50e6.png)
