### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ it will generate the same prompt.
 ### Manual
 
 ```zsh
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ~/powerlevel10k
-echo 'source ~/powerlevel10k/powerlevel10k.zsh-theme' >>! ~/.zshrc
+git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ~/.oh-my-zsh/themes/powerlevel10k
+echo 'source ~/.oh-my-zsh/themes/powerlevel10k/powerlevel10k.zsh-theme' >>! ~/.zshrc
 ```
 
 This is the simplest kind of installation and it works even if you are using a plugin manager. Just
@@ -60,10 +60,16 @@ make sure to disable your current theme in your plugin manager. See
 ### Oh My Zsh
 
 ```zsh
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $ZSH_CUSTOM/themes/powerlevel10k
+git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ~/.oh-my-zsh/themes/powerlevel10k
 ```
 
-Set `ZSH_THEME=powerlevel10k/powerlevel10k` in your `~/.zshrc`.
+Set 
+
+`ZSH_THEME=powerlevel10k/powerlevel10k` 
+and
+`source ~/.oh-my-zsh/themes/powerlevel10k/powerlevel10k.zsh-theme`
+
+in your `~/.zshrc`.
 
 ### Prezto
 


### PR DESCRIPTION
Coming from powerlevel9k, I notice that a step was missing in the current setup instruction.
Just add `source ~/.oh-my-zsh/themes/powerlevel10k/powerlevel10k.zsh-theme` in the `.zshrc` file.
Without it, it doesn't load.

And there was also some differences along the setup description, the path where the theme goes wasn't the same all along.
I suggest to use the default location of the zsh theme.

Hope it helps :) 
Thx for your work, love it !