### PR TITLE
Better virtualenv indicator

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3126,7 +3126,7 @@ prompt_virtualenv() {
   if (( _POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION )) && _p9k_python_version; then
     msg="${_p9k_ret//\%/%%} "
   fi
-  local v=${VIRTUAL_ENV:t}
+  local v=${VIRTUAL_ENV:h:t}
   (( _POWERLEVEL9K_VIRTUALENV_GENERIC_NAMES[(I)$v] )) && v=${VIRTUAL_ENV:h:t}
   msg+="$_POWERLEVEL9K_VIRTUALENV_LEFT_DELIMITER${v//\%/%%}$_POWERLEVEL9K_VIRTUALENV_RIGHT_DELIMITER"
   _p9k_prompt_segment "$0" "blue" "$_p9k_color1" 'PYTHON_ICON' 0 '' "$msg"


### PR DESCRIPTION
With this change the virtualenv plugin will display not the
virtualenv local folder name but the folder in which virtualenv is
located.
So, assuming these operations are executed
```
$ cd my_project
$ virtualenv venv
$ source venv/bin/activate
```
te virtualenv indicator with show `my_project` instead of `venv`.