### PR TITLE
Add prompt for Google Cloud application credentials

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -67,7 +67,8 @@
       aws                     # aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
       # aws_eb_env            # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
       # azure                 # azure account name (https://docs.microsoft.com/en-us/cli/azure)
-      # gcloud                # google cloud acccount and project (https://cloud.google.com/)
+      # gcloud                # google cloud cli acccount and project (https://cloud.google.com/)
+      # gcloud_app            # google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable)
       context                 # user@hostname
       nordvpn                 # nordvpn connection status, linux only (https://nordvpn.com/)
       ranger                  # ranger shell (https://github.com/ranger/ranger)
@@ -784,6 +785,23 @@
 
   # Custom icon.
   # typeset -g POWERLEVEL9K_GCLOUD_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
+  ##########[ gcloud_app: google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable) ]###########
+  # Google cloud color.
+  typeset -g POWERLEVEL9K_GCLOUD_APP_FOREGROUND=32
+
+  # Google cloud format. Uncomment POWERLEVEL9K_GCLOUD_APP_CONTENT_EXPANSION and edit its value if the
+  # default is too verbose.
+  #
+  #   P9K_GCLOUD_APP_EMAIL: `.client_email` field of keyfile
+  #   P9K_GCLOUD_APP_ACCOUNT_TYPE: `.type` field of keyfile
+  #   P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT: `sa` if `type=service_account`, empty otherwise
+  #   ${VARIABLE//\%/%%}: ${VARIABLE} with all occurences of '%' replaced with '%%'.
+  #
+  # typeset -g POWERLEVEL9K_GCLOUD_APP_CONTENT_EXPANSION='${P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT//\%/%%}${P9K_GCLOUD_APP_EMAIL//\%/%%}'
+
+  # Custom icon.
+  # typeset -g POWERLEVEL9K_GCLOUD_APP_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -68,6 +68,7 @@
       # aws_eb_env            # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
       # azure                 # azure account name (https://docs.microsoft.com/en-us/cli/azure)
       # gcloud                # google cloud acccount and project (https://cloud.google.com/)
+      # gcloud_app            # google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable)
       context                 # user@hostname
       nordvpn                 # nordvpn connection status, linux only (https://nordvpn.com/)
       ranger                  # ranger shell (https://github.com/ranger/ranger)
@@ -841,6 +842,23 @@
 
   # Custom icon.
   # typeset -g POWERLEVEL9K_GCLOUD_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
+  ##########[ gcloud_app: google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable) ]###########
+  # Google cloud color.
+  typeset -g POWERLEVEL9K_GCLOUD_APP_FOREGROUND=32
+
+  # Google cloud format. Uncomment POWERLEVEL9K_GCLOUD_APP_CONTENT_EXPANSION and edit its value if the
+  # default is too verbose.
+  #
+  #   P9K_GCLOUD_APP_EMAIL: `.client_email` field of keyfile
+  #   P9K_GCLOUD_APP_ACCOUNT_TYPE: `.type` field of keyfile
+  #   P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT: `sa` if `type=service_account`, empty otherwise
+  #   ${VARIABLE//\%/%%}: ${VARIABLE} with all occurences of '%' replaced with '%%'.
+  #
+  # typeset -g POWERLEVEL9K_GCLOUD_APP_CONTENT_EXPANSION='${P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT//\%/%%}${P9K_GCLOUD_APP_EMAIL//\%/%%}'
+
+  # Custom icon.
+  # typeset -g POWERLEVEL9K_GCLOUD_APP_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   ###############################[ public_ip: public IP address ]###############################
   # Public IP color.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -67,7 +67,7 @@
       aws                     # aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
       # aws_eb_env            # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
       # azure                 # azure account name (https://docs.microsoft.com/en-us/cli/azure)
-      # gcloud                # google cloud acccount and project (https://cloud.google.com/)
+      # gcloud                # google cloud cli acccount and project (https://cloud.google.com/)
       # gcloud_app            # google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable)
       context                 # user@hostname
       nordvpn                 # nordvpn connection status, linux only (https://nordvpn.com/)

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -67,7 +67,7 @@
       aws                     # aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
       # aws_eb_env            # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
       # azure                 # azure account name (https://docs.microsoft.com/en-us/cli/azure)
-      # gcloud                # google cloud acccount and project (https://cloud.google.com/)
+      # gcloud                # google cloud cli acccount and project (https://cloud.google.com/)
       # gcloud_app            # google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable)
       context                 # user@hostname
       nordvpn                 # nordvpn connection status, linux only (https://nordvpn.com/)

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -68,6 +68,7 @@
       # aws_eb_env            # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
       # azure                 # azure account name (https://docs.microsoft.com/en-us/cli/azure)
       # gcloud                # google cloud acccount and project (https://cloud.google.com/)
+      # gcloud_app            # google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable)
       context                 # user@hostname
       nordvpn                 # nordvpn connection status, linux only (https://nordvpn.com/)
       ranger                  # ranger shell (https://github.com/ranger/ranger)
@@ -809,6 +810,23 @@
 
   # Custom icon.
   # typeset -g POWERLEVEL9K_GCLOUD_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
+  ##########[ gcloud_app: google cloud application credentials (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable) ]###########
+  # Google cloud color.
+  typeset -g POWERLEVEL9K_GCLOUD_APP_FOREGROUND=32
+
+  # Google cloud format. Uncomment POWERLEVEL9K_GCLOUD_APP_CONTENT_EXPANSION and edit its value if the
+  # default is too verbose.
+  #
+  #   P9K_GCLOUD_APP_EMAIL: `.client_email` field of keyfile
+  #   P9K_GCLOUD_APP_ACCOUNT_TYPE: `.type` field of keyfile
+  #   P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT: `sa` if `type=service_account`, empty otherwise
+  #   ${VARIABLE//\%/%%}: ${VARIABLE} with all occurences of '%' replaced with '%%'.
+  #
+  # typeset -g POWERLEVEL9K_GCLOUD_APP_CONTENT_EXPANSION='${P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT//\%/%%}${P9K_GCLOUD_APP_EMAIL//\%/%%}'
+
+  # Custom icon.
+  # typeset -g POWERLEVEL9K_GCLOUD_APP_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3389,7 +3389,7 @@ prompt_gcloud() {
 }
 
 prompt_gcloud_app() {
-  unset P9K_GCLOUD_APP_EMAIL
+  unset P9K_GCLOUD_APP_EMAIL P9K_GCLOUD_APP_ACCOUNT_TYPE P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT
   (( $+commands[gcloud] )) || return
   [[ ! -z $GOOGLE_APPLICATION_CREDENTIALS ]] || return
 

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3379,7 +3379,6 @@ prompt_azure() {
 prompt_gcloud() {
   unset P9K_GCLOUD_PROJECT P9K_GCLOUD_ACCOUNT
   (( $+commands[gcloud] )) || return
-  local cfg=${AZURE_CONFIG_DIR:-$HOME/.azure}/azureProfile.json
   if ! _p9k_cache_stat_get $0 ~/.config/gcloud/active_config ~/.config/gcloud/configurations/config_default; then
     _p9k_cache_stat_set "$(gcloud config get-value account 2>/dev/null)" "$(gcloud config get-value project 2>/dev/null)"
   fi
@@ -3387,6 +3386,29 @@ prompt_gcloud() {
   P9K_GCLOUD_ACCOUNT=$_p9k_cache_val[1]
   P9K_GCLOUD_PROJECT=$_p9k_cache_val[2]
   _p9k_prompt_segment "$0" "blue" "white" "GCLOUD_ICON" 0 '' "${P9K_GCLOUD_ACCOUNT//\%/%%}:${P9K_GCLOUD_PROJECT//\%/%%}"
+}
+
+prompt_gcloud_app() {
+  unset P9K_GCLOUD_APP_EMAIL
+  (( $+commands[gcloud] )) || return
+  [[ ! -z $GOOGLE_APPLICATION_CREDENTIALS ]] || return
+
+  if ! _p9k_cache_stat_get $0 $GOOGLE_APPLICATION_CREDENTIALS; then
+    local email="$(cat $GOOGLE_APPLICATION_CREDENTIALS | jq -r '.client_email')"
+    local account_type="$(cat $GOOGLE_APPLICATION_CREDENTIALS | jq -r '.type')"
+    local account_type_short
+    if [[ "$account_type" == "service_account" ]]; then
+      account_type_short="sa:"
+    fi
+
+    # Service account name may contain only alpha-numeric chars and hyphens, so splitting by `.` gives us `service-account-name@project-id`
+    _p9k_cache_stat_set "${email%%.*}" "$account_type" "$account_type_short"
+  fi
+  [[ -n $_p9k_cache_val[1] || -n $_p9k_cache_val[2] || -n $_p9k_cache_val[3] ]] || return
+  P9K_GCLOUD_APP_EMAIL=$_p9k_cache_val[1]
+  P9K_GCLOUD_APP_ACCOUNT_TYPE=$_p9k_cache_val[2]
+  P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT=$_p9k_cache_val[3]
+  _p9k_prompt_segment "$0" "blue" "white" "GCLOUD_ICON" 0 '' "${P9K_GCLOUD_APP_ACCOUNT_TYPE_SHORT//\%/%%}${P9K_GCLOUD_APP_EMAIL//\%/%%}"
 }
 
 typeset -gra __p9k_nordvpn_tag=(


### PR DESCRIPTION
The prompt for GCloud that was recently added (btw, many thanks @romkatv!) is showing credentials that are being used by `gcloud` CLI. However, those creds cannot be used directly by any other application (like your Python app or Terraform) -- [you'll need to use a JSON keyfile for that purpose](https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable). This PR adds an additional prompt segment for GCloud that displays information about the keyfile.