### PR TITLE
add openshift `oc` to kubernetes context

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,8 +495,8 @@ a releavant tool.
 
 ```zsh
 # Show prompt segment "kubecontext" only when the command you are typing
-# invokes kubectl, helm, kubens or kubectx.
-typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx'
+# invokes kubectl, helm, kubens, kubectx or oc.
+typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc'
 ```
 
 Configs created by `p10k configure` may contain parameters of this kind. To customize when different

--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -808,7 +808,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -781,7 +781,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -781,7 +781,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -837,7 +837,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.


### PR DESCRIPTION
`oc` is the default command name for working with Kubernates/OpenShift installations. 

With this it gets activated by default.