### PR TITLE
Readonly fix

### DIFF
--- a/internal/configure.zsh
+++ b/internal/configure.zsh
@@ -10,7 +10,7 @@ typeset -gr __p9k_zshrc=${${:-$__p9k_zd/.zshrc}:A}
 typeset -gr __p9k_zshrc_u=$__p9k_zd_u/.zshrc
 typeset -gr __p9k_root_dir_u=${${${(q)__p9k_root_dir}/#(#b)${(q)HOME}(|\/*)/'~'$match[1]}//\%/%%}
 
-typeset -gr __p9k_readonly_zsh=$(test ! -e $__p9k_zshrc || test -w $__p9k_zshrc)
+typeset -gr __p9k_writeable_zsh=$(test ! -e $__p9k_zshrc || test -w $__p9k_zshrc)
 
 function _p9k_can_configure() {
   [[ $1 == '-q' ]] && local -i q=1 || local -i q=0

--- a/internal/configure.zsh
+++ b/internal/configure.zsh
@@ -10,8 +10,6 @@ typeset -gr __p9k_zshrc=${${:-$__p9k_zd/.zshrc}:A}
 typeset -gr __p9k_zshrc_u=$__p9k_zd_u/.zshrc
 typeset -gr __p9k_root_dir_u=${${${(q)__p9k_root_dir}/#(#b)${(q)HOME}(|\/*)/'~'$match[1]}//\%/%%}
 
-typeset -gr __p9k_writeable_zsh=$(test ! -e $__p9k_zshrc || test -w $__p9k_zshrc)
-
 function _p9k_can_configure() {
   [[ $1 == '-q' ]] && local -i q=1 || local -i q=0
   function $0_error() {

--- a/internal/configure.zsh
+++ b/internal/configure.zsh
@@ -10,6 +10,8 @@ typeset -gr __p9k_zshrc=${${:-$__p9k_zd/.zshrc}:A}
 typeset -gr __p9k_zshrc_u=$__p9k_zd_u/.zshrc
 typeset -gr __p9k_root_dir_u=${${${(q)__p9k_root_dir}/#(#b)${(q)HOME}(|\/*)/'~'$match[1]}//\%/%%}
 
+typeset -gr __p9k_readonly_zsh=$(test ! -e $__p9k_zshrc || test -w $__p9k_zshrc)
+
 function _p9k_can_configure() {
   [[ $1 == '-q' ]] && local -i q=1 || local -i q=0
   function $0_error() {
@@ -43,10 +45,7 @@ function _p9k_can_configure() {
       $0_error "$__p9k_zshrc_u is not readable"
       return 1
     }
-    [[ ! -e $__p9k_zshrc || -w $__p9k_zshrc ]]                             || {
-      $0_error "$__p9k_zshrc_u is not writable"
-      return 1
-    }
+
     (( LINES >= __p9k_wizard_lines && COLUMNS >= __p9k_wizard_columns ))   || {
       $0_error "terminal size too small; must be at least $__p9k_wizard_columns x $__p9k_wizard_lines"
       return 1

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1506,6 +1506,7 @@ function ask_zshrc_edit() {
       r) return 1;;
       n) return 0;;
       y)
+        test $__p9k_readonly_zsh echo "Zshrc is readonly ignoring..."; return
         write_zshrc=1
         if [[ -n $zshrc_content ]]; then
           zshrc_backup="$(mktemp ${TMPDIR:-/tmp}/.zshrc.XXXXXXXXXX)" || quit -c
@@ -1911,6 +1912,7 @@ if [[ -n $zshrc_backup ]]; then
 fi
 
 generate_config || return
+
 change_zshrc    || return
 
 print -rP ""

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1912,7 +1912,6 @@ if [[ -n $zshrc_backup ]]; then
 fi
 
 generate_config || return
-
 change_zshrc    || return
 
 print -rP ""

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1506,7 +1506,7 @@ function ask_zshrc_edit() {
       r) return 1;;
       n) return 0;;
       y)
-        test $__p9k_readonly_zsh echo "Zshrc is readonly ignoring..."; return
+        test $__p9k_writeable_zsh || echo "Zshrc is readonly ignoring..."; return
         write_zshrc=1
         if [[ -n $zshrc_content ]]; then
           zshrc_backup="$(mktemp ${TMPDIR:-/tmp}/.zshrc.XXXXXXXXXX)" || quit -c

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1506,7 +1506,7 @@ function ask_zshrc_edit() {
       r) return 1;;
       n) return 0;;
       y)
-        test $__p9k_writeable_zsh || echo "Zshrc is readonly ignoring..."; return
+        [[ $__p9k_writeable_zsh ]] || echo "Zshrc is readonly ignoring..."; return
         write_zshrc=1
         if [[ -n $zshrc_content ]]; then
           zshrc_backup="$(mktemp ${TMPDIR:-/tmp}/.zshrc.XXXXXXXXXX)" || quit -c

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1506,7 +1506,7 @@ function ask_zshrc_edit() {
       r) return 1;;
       n) return 0;;
       y)
-        [[ $__p9k_writeable_zsh ]] || echo "Zshrc is readonly ignoring..."; return
+        [[ ! -e $__p9k_zshrc || -w $__p9k_zshrc ]] || echo "Zshrc is readonly ignoring..."; return
         write_zshrc=1
         if [[ -n $zshrc_content ]]; then
           zshrc_backup="$(mktemp ${TMPDIR:-/tmp}/.zshrc.XXXXXXXXXX)" || quit -c

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1506,7 +1506,7 @@ function ask_zshrc_edit() {
       r) return 1;;
       n) return 0;;
       y)
-        [[ ! -e $__p9k_zshrc || -w $__p9k_zshrc ]] || echo "Zshrc is readonly ignoring..."; return 1
+        [[ ! -e $__p9k_zshrc || -w $__p9k_zshrc ]] || (echo "Zshrc is readonly ignoring..."; return 1)
         write_zshrc=1
         if [[ -n $zshrc_content ]]; then
           zshrc_backup="$(mktemp ${TMPDIR:-/tmp}/.zshrc.XXXXXXXXXX)" || quit -c

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1506,7 +1506,7 @@ function ask_zshrc_edit() {
       r) return 1;;
       n) return 0;;
       y)
-        [[ ! -e $__p9k_zshrc || -w $__p9k_zshrc ]] || echo "Zshrc is readonly ignoring..."; return
+        [[ ! -e $__p9k_zshrc || -w $__p9k_zshrc ]] || echo "Zshrc is readonly ignoring..."; return 1
         write_zshrc=1
         if [[ -n $zshrc_content ]]; then
           zshrc_backup="$(mktemp ${TMPDIR:-/tmp}/.zshrc.XXXXXXXXXX)" || quit -c


### PR DESCRIPTION
Some users. People like those who are using [`nixos`](https://github.com/rycee/home-manager) actually keep their `.zshrc` read-only. This became a problem because the configuration wizard would require that `.zshrc` was writeable to run. I instead have the configuration wizard warn the user if their `.zshrc` is read-only if they chose to modify their `.zshrc`.