### PR TITLE
Option to show/hide virtualenv name

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -868,6 +868,8 @@
   ###[ virtualenv: python virtual environment (https://docs.python.org/3/library/venv.html) ]###
   # Python virtual environment color.
   typeset -g POWERLEVEL9K_VIRTUALENV_FOREGROUND=37
+  # Show Python virtual environment name.
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME=true
   # Don't show Python version next to the virtual environment name.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false
   # Separate environment name from Python version only with a space.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -847,6 +847,8 @@
   ###[ virtualenv: python virtual environment (https://docs.python.org/3/library/venv.html) ]###
   # Python virtual environment color.
   typeset -g POWERLEVEL9K_VIRTUALENV_FOREGROUND=6
+  # Show Python virtual environment name.
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME=true
   # Don't show Python version next to the virtual environment name.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false
   # Separate environment name from Python version only with a space.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -847,6 +847,8 @@
   ###[ virtualenv: python virtual environment (https://docs.python.org/3/library/venv.html) ]###
   # Python virtual environment color.
   typeset -g POWERLEVEL9K_VIRTUALENV_FOREGROUND=37
+  # Show Python virtual environment name.
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME=true
   # Don't show Python version next to the virtual environment name.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false
   # Separate environment name from Python version only with a space.

--- a/config/p10k-pure.zsh
+++ b/config/p10k-pure.zsh
@@ -90,6 +90,8 @@
 
   # Grey Python Virtual Environment.
   typeset -g POWERLEVEL9K_VIRTUALENV_FOREGROUND=$grey
+  # Show Python virtual environment name.
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME=true
   # Don't show Python version.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false
   typeset -g POWERLEVEL9K_VIRTUALENV_{LEFT,RIGHT}_DELIMITER=

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -901,6 +901,8 @@
   # Python virtual environment color.
   # typeset -g POWERLEVEL9K_VIRTUALENV_FOREGROUND=0
   # typeset -g POWERLEVEL9K_VIRTUALENV_BACKGROUND=4
+  # Show Python virtual environment name.
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME=true
   # Don't show Python version next to the virtual environment name.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false
   # Separate environment name from Python version only with a space.

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3866,11 +3866,14 @@ instant_prompt_vi_mode() {
 prompt_virtualenv() {
   local msg=''
   if (( _POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION )) && _p9k_python_version; then
-    msg="${_p9k__ret//\%/%%} "
+    msg="${_p9k__ret//\%/%%}"
   fi
-  local v=${VIRTUAL_ENV:t}
-  (( _POWERLEVEL9K_VIRTUALENV_GENERIC_NAMES[(I)$v] )) && v=${VIRTUAL_ENV:h:t}
-  msg+="$_POWERLEVEL9K_VIRTUALENV_LEFT_DELIMITER${v//\%/%%}$_POWERLEVEL9K_VIRTUALENV_RIGHT_DELIMITER"
+  if (( _POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME )); then
+    local v=${VIRTUAL_ENV:t}
+    (( _POWERLEVEL9K_VIRTUALENV_GENERIC_NAMES[(I)$v] )) && v=${VIRTUAL_ENV:h:t}
+    [ -z "$msg" ] || msg+=" "
+    msg+="$_POWERLEVEL9K_VIRTUALENV_LEFT_DELIMITER${v//\%/%%}$_POWERLEVEL9K_VIRTUALENV_RIGHT_DELIMITER"
+  fi
   _p9k_prompt_segment "$0" "blue" "$_p9k_color1" 'PYTHON_ICON' 0 '' "$msg"
 }
 
@@ -6658,6 +6661,7 @@ _p9k_init_params() {
   # OVERWRITE mode is shown as INSERT unless POWERLEVEL9K_VI_OVERWRITE_MODE_STRING is explicitly set.
   _p9k_declare -e POWERLEVEL9K_VI_OVERWRITE_MODE_STRING
   _p9k_declare -b POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION 1
+  _p9k_declare -b POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME 1
   _p9k_declare -e POWERLEVEL9K_VIRTUALENV_LEFT_DELIMITER "("
   _p9k_declare -e POWERLEVEL9K_VIRTUALENV_RIGHT_DELIMITER ")"
   _p9k_declare -a POWERLEVEL9K_VIRTUALENV_GENERIC_NAMES -- virtualenv venv .venv


### PR DESCRIPTION
Add an option to show/hide virtualenv name.

Adds `POWERLEVEL9K_VIRTUALENV_SHOW_ENV_NAME` for the `virtualenv` segment.