### PR TITLE
Add 'kogito' to POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ Here's the relevant parameter for kubernetes context:
 
 ```zsh
 # Show prompt segment "kubecontext" only when the command you are typing
-# invokes kubectl, helm, kubens, kubectx, oc or istioctl.
-typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl'
+# invokes kubectl, helm, kubens, kubectx, oc, istioctl or kogito.
+typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito'
 ```
 
 To customize when different prompt segments are shown, open `~/.p10k.zsh`, search for
@@ -803,8 +803,8 @@ a relevant tool.
 
 ```zsh
 # Show prompt segment "kubecontext" only when the command you are typing
-# invokes kubectl, helm, kubens, kubectx, oc or istioctl.
-typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl'
+# invokes kubectl, helm, kubens, kubectx, oc, istioctl or kogito.
+typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito'
 ```
 
 Configs created by `p10k configure` may contain parameters of this kind. To customize when different

--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -1116,7 +1116,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -1064,7 +1064,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -1064,7 +1064,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -1173,7 +1173,7 @@
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.
-  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl'
+  typeset -g POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND='kubectl|helm|kubens|kubectx|oc|istioctl|kogito'
 
   # Kubernetes context classes for the purpose of using different colors, icons and expansions with
   # different contexts.


### PR DESCRIPTION
Signed-off-by: David Ward <dward@redhat.com>

Just like OpenShift (and it's `oc` command) and Istio (and it's `istioctl` command) are Red Hat-backed offerings that build on Kubernetes, Kogito (and it's `kogito` command) is also a Red Hat offering that then builds on OpenShift.

The Kogito ( https://kogito.kie.org/ ) project's goal is to simplify the development and deployment of business rules and processes applications in a cloud-native fashion, and represents the current and future direction Red Hat's Business Automation products in the cloud.

`kogito` requires `oc` to be installed, since it aggregates and simplifies more manual `oc` tasks for the user. ( https://github.com/kiegroup/kogito-cloud-operator#kogito-cli ) Just like the other `POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND`  commands, it is kubernetes context-aware, and the dynamic appearance of the context in Powerlevel10k woudl be very helpful. (In fact, I've adjusted my own ~/.p10k.zsh to add it already. This PR is just so that it comes with Powerlevel10k out of the box.)

For transparency, I am a Red Hat employee on the Cloud Business Automation team who has contributed to RHBA, OpenShift, and Kogito projects myself. :)

