### PR TITLE
Change subseparator color to match with segment

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -684,7 +684,7 @@ _p9k_left_prompt_segment() {
       fi
       _p9k_t+=%b$bg$_p9k__ret$ss$style$left_space  # 3
     else
-      _p9k_t+=%b$bg$fg$ss$style$left_space           # 3
+      _p9k_t+=%b$bg$ss$fg$style$left_space           # 3
     fi
     _p9k_t+=%b$bg$s$style$left_space                 # 4
 
@@ -911,7 +911,7 @@ _p9k_right_prompt_segment() {
     local t=$(($#_p9k_t - __p9k_ksh_arrays))
     _p9k_t+=$start_sep$style$left_space           # 1
     _p9k_t+=$w$style                              # 2
-    _p9k_t+=$w$subsep$style$left_space            # 3
+    _p9k_t+=$w$style$subsep$left_space            # 3
     _p9k_t+=$w%F{$bg_color}$sep$style$left_space  # 4
 
     local join="_p9k__i>=$_p9k_right_join[$_p9k__segment_index]"


### PR DESCRIPTION
This is a totally subjective opinion, that said I think that the color of the subsegment icon of two adjacent segments that share the same background is colored after the wrong segment.

Current style:
![current](https://user-images.githubusercontent.com/1241721/76033187-f49f2100-5f3b-11ea-8204-f2fd4edf4983.png)

Modified style:
![modified](https://user-images.githubusercontent.com/1241721/76033207-fc5ec580-5f3b-11ea-8a8a-0c1b3820b1bb.png)

I understand if some people don't agree with me on this and this change is not approved to be merged. In that case it could be modified based on a configuration parameter.