### PR TITLE
Update GitHub issue link

### DIFF
--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -2207,5 +2207,5 @@ generate_config || return
 change_zshrc    || return
 
 print -rP ""
-flowing +c File feature requests and bug reports at "$(href https://github.com/romkatv/powerlevel10k/issues)."
+flowing +c File feature requests and bug reports at "$(href https://github.com/romkatv/powerlevel10k/issues)"
 print -rP ""


### PR DESCRIPTION
[Description]
I can not open the GitHub issue page, because the link joins ".(period)" string. 

[ScreenShot]
<img width="1330" alt="Screen Shot 2020-03-26 at 1 21 20" src="https://user-images.githubusercontent.com/4537402/77644912-2f2d3400-6fa5-11ea-85d6-53b9f1d8add2.png">
