### PR TITLE
Fix Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ echo 'source /usr/local/opt/powerlevel10k/powerlevel10k.zsh-theme' >>! ~/.zshrc
 ### Arch Linux
 
 ```zsh
-pacman -Sy --noconfirm zsh-theme-powerlevel10k
+pacman -S --noconfirm zsh-theme-powerlevel10k
 echo 'source /usr/share/zsh-theme-powerlevel10k/powerlevel10k.zsh-theme' >>! ~/.zshrc
 ```
 


### PR DESCRIPTION
`pacman -Sy` does a partial upgrade, which is [specifically documented as being unsupported](https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported).