### PR TITLE
Fix _p9k_precmd:trap:17: undefined signal: return

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -6441,7 +6441,7 @@ _p9k_precmd() {
 
   # See https://www.zsh.org/mla/workers/2020/msg00612.html for the reason behind __p9k_trapint.
   typeset -g __p9k_trapint='_p9k_trapint; return 130'
-  trap $__p9k_trapint INT
+  trap "$__p9k_trapint" INT
 }
 
 function _p9k_reset_prompt() {


### PR DESCRIPTION
Hi,

For me this change 5d41bf4 cause :  _p9k_precmd:trap:17: undefined signal: return

I just protect it by use quotes.