### PR TITLE
Fix warning for parameter _p9k__preexec_cmd

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5253,7 +5253,7 @@ _p9k_preexec1() {
 }
 
 _p9k_preexec2() {
-  _p9k__preexec_cmd=$2
+  typeset -g _p9k__preexec_cmd=$2
   _p9k__timer_start=EPOCHREALTIME
 }
 


### PR DESCRIPTION
With `setopt warn_create_global`, I get this warning:

```
_p9k_preexec2:1: scalar parameter _p9k__preexec_cmd created globally in function _p9k_preexec2
```