### PR TITLE
fix battery prompt on pinebook pro

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -1270,7 +1270,7 @@ _p9k_prompt_battery_init() {
     return
   fi
   if [[ $_p9k_os != (Linux|Android) ||
-        -z /sys/class/power_supply/(CMB*|BAT*|battery)/(energy_full|charge_full|charge_counter)(#qN) ]]; then
+        -z /sys/class/power_supply/(CMB*|BAT*|*battery)/(energy_full|charge_full)(#qN) ]]; then
     typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='${:-}'
   fi
 }
@@ -1328,7 +1328,7 @@ _p9k_prompt_battery_set_args() {
 
     Linux|Android)
       # See https://sourceforge.net/projects/acpiclient.
-      local -a bats=( /sys/class/power_supply/(CMB*|BAT*|battery)/(FN) )
+      local -a bats=( /sys/class/power_supply/(CMB*|BAT*|*battery)/(FN) )
       (( $#bats )) || return
 
       local -i energy_now energy_full power_now
@@ -1336,7 +1336,7 @@ _p9k_prompt_battery_set_args() {
       local dir
       for dir in $bats; do
         local -i pow=0 full=0
-        if _p9k_read_file $dir/(energy_full|charge_full|charge_counter)(N); then
+        if _p9k_read_file $dir/(energy_full|charge_full)(N); then
           (( energy_full += ${full::=_p9k__ret} ))
         fi
         if _p9k_read_file $dir/(power|current)_now(N) && (( $#_p9k__ret < 9 )); then


### PR DESCRIPTION
On my pinebook pro the battery level indication did not work, this PR contains the changes I had to make to fix this;

* The device is called `/sys/class/power_supply/cw2015-battery`, therefore I replaced `battery` with `*battery` twice.
* `charge_counter` contains an unusable value, so I removed that.

As the last change might cause problems for others, I checked https://www.kernel.org/doc/html/latest/power/power_supply_class.html which explains:

> CHARGE_COUNTER
>     the current charge counter (in µAh). This could easily be negative; there is no empty or full value. It is only useful for relative, time-based measurements.

Based on this description, it should not be useful to calculate the battery level. The usage of `charge_counter` was added in commit 6a1f0659 for #88. I don't see a reason for the change there. In that ticket you also ask for some diagnostics, I'll also provide that, but a slightly modified version;
```
() {
  emulate -L zsh && setopt xtrace null_glob
  echo OS=$OS
  uname
  uname -o
  uname -a
  ls /sys/class/power_supply/(BAT*|*battery)/
  cat /dev/null /sys/class/power_supply/(BAT*|*battery)/(energy|charge)_now
  cat /dev/null /sys/class/power_supply/(BAT*|*battery)/(energy|charge)_full
  cat /dev/null /sys/class/power_supply/(BAT*|*battery)/(power|current)_now
  cat /dev/null /sys/class/power_supply/(BAT*|*battery)/status
  cat /dev/null /sys/class/power_supply/(BAT*|*battery)/capacity
}

+(anon):2> echo 'OS=Linux'
OS=Linux
+(anon):3> uname
Linux
+(anon):4> uname -o
GNU/Linux
+(anon):5> uname -a
Linux pine1 5.5.0-1-pinebookpro-arm64 #1 SMP PREEMPT Wed Aug 12 04:14:48 UTC 2020 aarch64 GNU/Linux
+(anon):6> ls /sys/class/power_supply/cw2015-battery/
capacity	charge_full_design  health  present    technology	  type	       wakeup7
charge_counter	current_now	    hwmon5  status     temp		  uevent
charge_full	device		    power   subsystem  time_to_empty_now  voltage_now
+(anon):7> cat /dev/null
+(anon):8> cat /dev/null /sys/class/power_supply/cw2015-battery/charge_full
9800000
+(anon):9> cat /dev/null /sys/class/power_supply/cw2015-battery/current_now
1189674
+(anon):10> cat /dev/null /sys/class/power_supply/cw2015-battery/status
Discharging
+(anon):11> cat /dev/null /sys/class/power_supply/cw2015-battery/capacity
87
```
(`charge_counter` contains 3 right now)

Let me know if you need any further information.