### PR TITLE
Correct Python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Note how the effect of every command is instantly reflected by the very next pro
 | `timew start hack linux`      | `🛡️ hack linux`  | time tracking enabled in [timewarrior](https://timewarrior.net/)      |
 | `touch x y`                   | `?2`             | 2 untracked files in the Git repo                                     |
 | `rm COPYING`                  | `!1`             | 1 unstaged change in the Git repo                                     |
-| `echo 2.7.3 >.python-version` | `🐍 2.7.3`       | the current python version in [pyenv](https://github.com/pyenv/pyenv) |
+| `echo 3.7.3 >.python-version` | `🐍 3.7.3`       | the current python version in [pyenv](https://github.com/pyenv/pyenv) |
 
 Other Zsh themes capable of displaying the same information either produce prompt lag or print
 prompt that doesn't reflect the current state of the system and then refresh it later. With


### PR DESCRIPTION
The demonstration image shows `3.7.3` while the README writes `2.7.3`.
![image](https://user-images.githubusercontent.com/44045911/96707837-f8988a00-13ca-11eb-9758-5b1684ab7994.png)
