### PR TITLE
Update os icon at zsh.exe on git for windows

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -8044,7 +8044,7 @@ function _p9k_init_cacheable() {
     case $_p9k_uname in
       SunOS)                     _p9k_set_os Solaris SUNOS_ICON;;
       Darwin)                    _p9k_set_os OSX     APPLE_ICON;;
-      CYGWIN_NT-* | MSYS_NT-*)   _p9k_set_os Windows WINDOWS_ICON;;
+      CYGWIN_NT-*|MSYS_NT-*|MINGW64_NT-*|MINGW32_NT-*)   _p9k_set_os Windows WINDOWS_ICON;;
       FreeBSD|OpenBSD|DragonFly) _p9k_set_os BSD     FREEBSD_ICON;;
       Linux)
         _p9k_os='Linux'

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1070,7 +1070,7 @@ function os_icon_name() {
     case $uname in
       SunOS)                     echo SUNOS_ICON;;
       Darwin)                    echo APPLE_ICON;;
-      CYGWIN_NT-* | MSYS_NT-*)   echo WINDOWS_ICON;;
+      CYGWIN_NT-*|MSYS_NT-*|MINGW64_NT-*|MINGW32_NT-*)   echo WINDOWS_ICON;;
       FreeBSD|OpenBSD|DragonFly) echo FREEBSD_ICON;;
       Linux)
         local os_release_id


### PR DESCRIPTION
Windows icon is not shown on git for windows zsh.exe
Tried this update in windows 7(x86) , windows 8.1(x64)  on cmder_mini terminal and in windows 10(x64) on windows terminal app.
I've installed pacman on git for windows and then installed zsh package on it.
It simply works as same as other OS'es.