### PR TITLE
Change icon for the timewarrior segment to '⌚' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Note how the effect of every command is instantly reflected by the very next pro
 
 | Command                       | Prompt Indicator | Meaning                                                               |
 |-------------------------------|:----------------:|----------------------------------------------------------------------:|
-| `timew start hack linux`      | `🛡️ hack linux`  | time tracking enabled in [timewarrior](https://timewarrior.net/)      |
+| `timew start hack linux`      | `⌚ hack linux`  | time tracking enabled in [timewarrior](https://timewarrior.net/)      |
 | `touch x y`                   | `?2`             | 2 untracked files in the Git repo                                     |
 | `rm COPYING`                  | `!1`             | 1 unstaged change in the Git repo                                     |
 | `echo 3.7.3 >.python-version` | `🐍 3.7.3`       | the current python version in [pyenv](https://github.com/pyenv/pyenv) |


### PR DESCRIPTION
The icon for the timewarrior segment was changed from '🛡️' to '⌚' in https://github.com/romkatv/powerlevel10k/commit/c65260aaab46fee3d1eab033db258d0a366f03b4. This PR changes it in the README.md.

See also #1215