### PR TITLE
created trapint_functions:<array> to customize SIGINT trap function list

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -6710,6 +6710,10 @@ _p9k_trapint() {
   return 0
 }
 
+_p9k_return_130() {
+  return 130
+}
+
 _p9k_precmd() {
   __p9k_new_status=$?
   __p9k_new_pipestatus=($pipestatus)
@@ -6726,7 +6730,8 @@ _p9k_precmd() {
   setopt no_local_options no_prompt_bang prompt_percent prompt_subst prompt_cr prompt_sp
 
   # See https://www.zsh.org/mla/workers/2020/msg00612.html for the reason behind __p9k_trapint.
-  typeset -g __p9k_trapint='_p9k_trapint; return 130'
+  [[ -v trapint_functions ]] || typeset -ga trapint_functions=( _p9k_trapint _p9k_return_130 )
+  typeset -g __p9k_trapint="${(j.; .)trapint_functions}"
   trap "$__p9k_trapint" INT
 
   : ${(%):-%b%k%s%u}


### PR DESCRIPTION
`_p9k_precmd()` was resetting the trap for SIGINT on every call, making it impossible (due to [zsh’s local_traps bug](https://www.zsh.org/mla/workers/2020/msg00612.html)) to easily specify a custom trap function without overwriting the function `_p9k_trapint()`.

To allow for changes I've added a global array named `trapint_functions` (similar to zsh’s hook function arrays) that specifies a list of functions or commands that will be associated with the SIGINT trap.

With no changes to `trapint_functions`, the default behavior is the same as before e.g. calling `_p9k_trapint()` and returning 130 (even though the latter is now done by `_p9k_return_130()` for consistency).
