### PR TITLE
Fix bug which Wi-Fi cannot display

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5064,7 +5064,7 @@ _p9k_prompt_wifi_async() {
       # wlp3s0: 0000   58.  -52.  -256        0      0      0      0     76        0
       local -a lines
       lines=(${${(f)"$(</proc/net/wireless)"}:#*\|*}) || return 0
-      (( $#lines == 1 )) || return 0
+      (( $#lines >= 1 )) || return 0
       local parts=(${=lines[1]})
       iface=${parts[1]%:}
       state=${parts[2]}


### PR DESCRIPTION
in <https://github.com/romkatv/powerlevel10k/blob/master/internal/p10k.zsh#L5067>

```sh
(( $#lines == 1 )) || return 0
```

When `$#lines > 1`, the symbol of wifi will not display. After change this line, the symbol can work.

![Screenshot_2021-03-17-20-46-15-35](https://user-images.githubusercontent.com/32936898/111471585-01b43a00-8764-11eb-9093-464f2e56fc21.jpg)

