### PR TITLE
Sets the filter for the current gcloud profile

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4496,7 +4496,8 @@ _p9k_gcloud_prefetch() {
   if ! _p9k_cache_stat_get $0 ~/.config/gcloud/configurations/config_$P9K_GCLOUD_CONFIGURATION; then
     local pair account project_id
     pair="$(gcloud config configurations describe $P9K_GCLOUD_CONFIGURATION \
-      --format=$'value[separator="\1"](properties.core.account,properties.core.project)')"
+      --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
+      --filter=is_active:true)"
     (( ! $? )) && IFS=$'\1' read account project_id <<<$pair
     _p9k_cache_stat_set "$account" "$project_id"
   fi


### PR DESCRIPTION
When you have multiple profiles set up, you should only search for what is currently active.