### PR TITLE
Get active gcloud profile using `list` command

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4498,7 +4498,7 @@ _p9k_gcloud_prefetch() {
   P9K_GCLOUD_CONFIGURATION=$_p9k__ret
   if ! _p9k_cache_stat_get $0 ~/.config/gcloud/configurations/config_$P9K_GCLOUD_CONFIGURATION; then
     local pair account project_id
-    pair="$(gcloud config configurations describe $P9K_GCLOUD_CONFIGURATION \
+    pair="$(gcloud config configurations list $P9K_GCLOUD_CONFIGURATION \
       --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
       --filter=is_active:true)"
     (( ! $? )) && IFS=$'\1' read account project_id <<<$pair


### PR DESCRIPTION
`gcloud config configure describe` command does not have `--filter` option. To filter
the active profile using `--filter` it is necessary to use `gcloud config configure list`
command

This PR solves #1328