### PR TITLE
Fix gcloud CLI

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4504,7 +4504,10 @@ _p9k_gcloud_prefetch() {
   P9K_GCLOUD_CONFIGURATION=$_p9k__ret
   if ! _p9k_cache_stat_get $0 ~/.config/gcloud/configurations/config_$P9K_GCLOUD_CONFIGURATION; then
     local pair account project_id
-    pair="$(gcloud config configurations list $P9K_GCLOUD_CONFIGURATION \
+    pair="$(gcloud config configurations list --configuration $P9K_GCLOUD_CONFIGURATION \
+      --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
+      --filter=is_active:true 2>/dev/null)"
+    (( $? )) && pair="$(gcloud config configurations list $P9K_GCLOUD_CONFIGURATION \
       --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
       --filter=is_active:true)"
     (( ! $? )) && IFS=$'\1' read account project_id <<<$pair

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4504,9 +4504,8 @@ _p9k_gcloud_prefetch() {
   P9K_GCLOUD_CONFIGURATION=$_p9k__ret
   if ! _p9k_cache_stat_get $0 ~/.config/gcloud/configurations/config_$P9K_GCLOUD_CONFIGURATION; then
     local pair account project_id
-    pair="$(gcloud config configurations list --configuration $P9K_GCLOUD_CONFIGURATION \
-      --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
-      --filter=is_active:true)"
+    pair="$(gcloud config configurations describe $P9K_GCLOUD_CONFIGURATION \
+      --format=$'value[separator="\1"](properties.core.account,properties.core.project)')"
     (( ! $? )) && IFS=$'\1' read account project_id <<<$pair
     _p9k_cache_stat_set "$account" "$project_id"
   fi

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4506,9 +4506,6 @@ _p9k_gcloud_prefetch() {
     local pair account project_id
     pair="$(gcloud config configurations list --configuration $P9K_GCLOUD_CONFIGURATION \
       --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
-      --filter=is_active:true 2>/dev/null)"
-    (( $? )) && pair="$(gcloud config configurations list $P9K_GCLOUD_CONFIGURATION \
-      --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
       --filter=is_active:true)"
     (( ! $? )) && IFS=$'\1' read account project_id <<<$pair
     _p9k_cache_stat_set "$account" "$project_id"


### PR DESCRIPTION
The configuration name needs to be passed to `gcloud config configurations list` using the `--configuration` argument.