### PR TITLE
Clear the SEGMENT_SYMBOL when we don't want background color 

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -600,7 +600,7 @@ _p9k_escape() {
 #       the segment isn't rendered.
 # * $7: Content.
 _p9k_left_prompt_segment() {
-  if ! _p9k_cache_get "$0" "$1" "$2" "$3" "$4" "$_p9k__segment_index"; then
+  if _p9k_cache_get "$0" "$1" "$2" "$3" "$4" "$_p9k__segment_index"; then
     _p9k_color $1 BACKGROUND $2
     local bg_color=$_p9k__ret
     _p9k_background $bg_color
@@ -637,7 +637,7 @@ _p9k_left_prompt_segment() {
     _p9k_get_icon $1 LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL $sep
     _p9k_escape $_p9k__ret
     local end_sep_=$_p9k__ret
-    if [[ $bg_color -eq 0 ]];then
+    if [[ -z $bg_color ]];then
       end_sep_=''
     fi
 
@@ -871,7 +871,7 @@ _p9k_right_prompt_segment() {
 
     _p9k_get_icon $1 RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL $sep
     local start_sep=$_p9k__ret
-    [[ 0 -eq $bg_color ]] && start_sep=''
+    [[ -z $bg_color ]] && start_sep=''
     [[ -n $start_sep ]] && start_sep="%b%k%F{$bg_color}$start_sep"
 
     _p9k_get_icon $1 RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -637,7 +637,10 @@ _p9k_left_prompt_segment() {
     _p9k_get_icon $1 LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL $sep
     _p9k_escape $_p9k__ret
     local end_sep_=$_p9k__ret
+
+    # clear sperate symbol in transparent mode 
     if [[ -z $bg_color ]];then
+      start_sep=''
       end_sep_=''
     fi
 
@@ -871,14 +874,17 @@ _p9k_right_prompt_segment() {
 
     _p9k_get_icon $1 RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL $sep
     local start_sep=$_p9k__ret
-    if [[ -z $bg_color ]];then
-      start_sep=''
-    fi
     [[ -n $start_sep ]] && start_sep="%b%k%F{$bg_color}$start_sep"
 
     _p9k_get_icon $1 RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL
     _p9k_escape $_p9k__ret
     local end_sep_=$_p9k__ret
+
+    # clear sperate symbol in transparent mode 
+    if [[ -z $bg_color ]];then
+      start_sep=''
+      end_sep_=''
+    fi
 
     _p9k_get_icon $1 WHITESPACE_BETWEEN_RIGHT_SEGMENTS ' '
     local space=$_p9k__ret

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -637,6 +637,9 @@ _p9k_left_prompt_segment() {
     _p9k_get_icon $1 LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL $sep
     _p9k_escape $_p9k__ret
     local end_sep_=$_p9k__ret
+    if [[ $bg_color -eq 0 ]];then
+      end_sep_=''
+    fi
 
     _p9k_get_icon $1 WHITESPACE_BETWEEN_LEFT_SEGMENTS ' '
     local space=$_p9k__ret
@@ -868,6 +871,7 @@ _p9k_right_prompt_segment() {
 
     _p9k_get_icon $1 RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL $sep
     local start_sep=$_p9k__ret
+    [[ 0 -eq $bg_color ]] && start_sep=''
     [[ -n $start_sep ]] && start_sep="%b%k%F{$bg_color}$start_sep"
 
     _p9k_get_icon $1 RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL
@@ -1049,6 +1053,7 @@ _p9k_right_prompt_segment() {
     p+='${_p9k__sss::='
     p+=$style_$right_space_
     [[ $right_space_ == *%* ]] && p+=$style_
+    
     if [[ -n $end_sep_ ]]; then
       p+="%k%F{$bg_color\}$end_sep_$style_"
     fi

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -600,7 +600,7 @@ _p9k_escape() {
 #       the segment isn't rendered.
 # * $7: Content.
 _p9k_left_prompt_segment() {
-  if _p9k_cache_get "$0" "$1" "$2" "$3" "$4" "$_p9k__segment_index"; then
+  if ! _p9k_cache_get "$0" "$1" "$2" "$3" "$4" "$_p9k__segment_index"; then
     _p9k_color $1 BACKGROUND $2
     local bg_color=$_p9k__ret
     _p9k_background $bg_color

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -871,7 +871,9 @@ _p9k_right_prompt_segment() {
 
     _p9k_get_icon $1 RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL $sep
     local start_sep=$_p9k__ret
-    [[ -z $bg_color ]] && start_sep=''
+    if [[ -z $bg_color ]];then
+      start_sep=''
+    fi
     [[ -n $start_sep ]] && start_sep="%b%k%F{$bg_color}$start_sep"
 
     _p9k_get_icon $1 RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL


### PR DESCRIPTION
## Situation 
When I set the background color to empty, the segment symbol is still printed out.
- settings in `.p10k.zsh`
![image](https://user-images.githubusercontent.com/32732820/115951525-c69be800-a513-11eb-90eb-72380de0e519.png)
![image](https://user-images.githubusercontent.com/32732820/115951672-838e4480-a514-11eb-8507-87d544848966.png)

There is still the '▶' symbol. (I don't know how to type this symbol... please forgive me :'( )

- output
![image](https://user-images.githubusercontent.com/32732820/115951636-504bb580-a514-11eb-85d4-537281cacae0.png)

## Solution
So I add some conditions in `p10k.zsh` to make the symbol disappear when the `bg_color` is not exist.  

- result
![image](https://user-images.githubusercontent.com/32732820/115952144-044e4000-a517-11eb-9e90-6710d505fadf.png)

