### PR TITLE
Add region support for aws element

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -1291,6 +1291,12 @@
   # Tip: Remove the next line to always show aws.
   typeset -g POWERLEVEL9K_AWS_SHOW_ON_COMMAND='aws|awless|terraform|pulumi|terragrunt'
 
+  # Include AWS region in prompt. (default: false)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION=false
+
+  # Shorten AWS region. (default: true)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION_SHORT=true
+
   # POWERLEVEL9K_AWS_CLASSES is an array with even number of elements. The first element
   # in each pair defines a pattern against which the current AWS profile gets matched.
   # More specifically, it's P9K_CONTENT prior to the application of context expansion (see below)

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -1272,6 +1272,12 @@
   # Tip: Remove the next line to always show aws.
   typeset -g POWERLEVEL9K_AWS_SHOW_ON_COMMAND='aws|awless|terraform|pulumi|terragrunt'
 
+  # Include AWS region in prompt. (default: false)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION=false
+
+  # Shorten AWS region. (default: true)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION_SHORT=true
+
   # POWERLEVEL9K_AWS_CLASSES is an array with even number of elements. The first element
   # in each pair defines a pattern against which the current AWS profile gets matched.
   # More specifically, it's P9K_CONTENT prior to the application of context expansion (see below)

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -1268,6 +1268,12 @@
   # Tip: Remove the next line to always show aws.
   typeset -g POWERLEVEL9K_AWS_SHOW_ON_COMMAND='aws|awless|terraform|pulumi|terragrunt'
 
+  # Include AWS region in prompt. (default: false)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION=false
+
+  # Shorten AWS region. (default: true)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION_SHORT=true
+
   # POWERLEVEL9K_AWS_CLASSES is an array with even number of elements. The first element
   # in each pair defines a pattern against which the current AWS profile gets matched.
   # More specifically, it's P9K_CONTENT prior to the application of context expansion (see below)

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -1360,6 +1360,12 @@
   # Tip: Remove the next line to always show aws.
   typeset -g POWERLEVEL9K_AWS_SHOW_ON_COMMAND='aws|awless|terraform|pulumi|terragrunt'
 
+  # Include AWS region in prompt. (default: false)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION=false
+
+  # Shorten AWS region. (default: true)
+  # typeset -g POWERLEVEL9K_AWS_SHOW_REGION_SHORT=true
+
   # POWERLEVEL9K_AWS_CLASSES is an array with even number of elements. The first element
   # in each pair defines a pattern against which the current AWS profile gets matched.
   # More specifically, it's P9K_CONTENT prior to the application of context expansion (see below)

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -1131,6 +1131,25 @@ _p9k_prompt_anaconda_init() {
 # AWS Profile
 prompt_aws() {
   local aws_profile="${AWS_VAULT:-${AWSUME_PROFILE:-${AWS_PROFILE:-$AWS_DEFAULT_PROFILE}}}"
+  local text="${aws_profile//\%/%%}"
+  if (( _POWERLEVEL9K_AWS_SHOW_REGION )); then
+    local region_full
+    if [[ -v $AWS_DEFAULT_REGION ]]; then
+      region_full=$AWS_DEFAULT_REGION
+    else
+      if ! _p9k_cache_get "$0-$aws_profile-full"; then
+        _p9k_cache_set $(aws configure get region)
+      fi
+      region_full=$_p9k__cache_val[1]
+    fi
+    if (( _POWERLEVEL9K_AWS_SHOW_REGION_SHORT )); then
+      local region_short=${${${${${${region_full//-}//north/n}//south/s}//east/e}//west/w}//gov/g}
+      text="$text ($region_short)"
+    else
+      text="$text ($region_full)"
+    fi
+  fi
+
   local pat class
   for pat class in "${_POWERLEVEL9K_AWS_CLASSES[@]}"; do
     if [[ $aws_profile == ${~pat} ]]; then
@@ -1138,7 +1157,7 @@ prompt_aws() {
       break
     fi
   done
-  _p9k_prompt_segment "$0$state" red white 'AWS_ICON' 0 '' "${aws_profile//\%/%%}"
+  _p9k_prompt_segment "$0$state" red white 'AWS_ICON' 0 '' "$text"
 }
 
 _p9k_prompt_aws_init() {
@@ -7379,6 +7398,8 @@ _p9k_init_params() {
   #   POWERLEVEL9K_KUBECONTEXT_OTHER_BACKGROUND=yellow
   _p9k_declare -a POWERLEVEL9K_KUBECONTEXT_CLASSES --
   _p9k_declare -a POWERLEVEL9K_AWS_CLASSES --
+  _p9k_declare -b POWERLEVEL9K_AWS_SHOW_REGION 0
+  _p9k_declare -b POWERLEVEL9K_AWS_SHOW_REGION_SHORT 1
   _p9k_declare -a POWERLEVEL9K_AZURE_CLASSES --
   _p9k_declare -a POWERLEVEL9K_TERRAFORM_CLASSES --
   _p9k_declare -b POWERLEVEL9K_TERRAFORM_SHOW_DEFAULT 0


### PR DESCRIPTION
Since `aws configure get region` takes about half a second to run, this adds a slight delay when changing `AWS_PROFILE` and at startup. Is there any way to avoid this?