### PR TITLE
New module for showing in prompt the active terraform version.

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -70,6 +70,7 @@
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
+    terraform_version       # It shows current active terraform version
     aws                     # aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
     aws_eb_env              # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
     azure                   # azure account name (https://docs.microsoft.com/en-us/cli/azure)

--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -1205,6 +1205,9 @@
   typeset -g POWERLEVEL9K_TERRAFORM_OTHER_FOREGROUND=38
   # typeset -g POWERLEVEL9K_TERRAFORM_OTHER_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
+  ################[ terraform_version: It shows active terraform version (https://www.terraform.io) ]#################
+  typeset -g POWERLEVEL9K_TERRAFORM_VERSION_SHOW_ON_COMMAND='terraform|tf'
+
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -70,6 +70,7 @@
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
+    terraform_version       # It shows current active terraform version
     aws                     # aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
     aws_eb_env              # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
     azure                   # azure account name (https://docs.microsoft.com/en-us/cli/azure)

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -70,6 +70,7 @@
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
+    terraform_version       # It shows current active terraform version
     aws                     # aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
     aws_eb_env              # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
     azure                   # azure account name (https://docs.microsoft.com/en-us/cli/azure)

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -70,6 +70,7 @@
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
+    terraform_version       # It shows current active terraform version
     aws                     # aws profile (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
     aws_eb_env              # aws elastic beanstalk environment (https://aws.amazon.com/elasticbeanstalk/)
     azure                   # azure account name (https://docs.microsoft.com/en-us/cli/azure)

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -1272,6 +1272,9 @@
   typeset -g POWERLEVEL9K_TERRAFORM_OTHER_BACKGROUND=0
   # typeset -g POWERLEVEL9K_TERRAFORM_OTHER_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
+  ################[ terraform_version: It shows active terraform version (https://www.terraform.io) ]#################
+  typeset -g POWERLEVEL9K_TERRAFORM_VERSION_SHOW_ON_COMMAND='terraform|tf'
+
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.
   # Tip: Remove the next line to always show kubecontext.

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4887,6 +4887,15 @@ _p9k_prompt_terraform_init() {
   typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$commands[terraform]'
 }
 
+function prompt_terraform_version() {
+  local terraform_version="$(command terraform --version)"
+  _p9k_prompt_segment "$0$state" $_p9k_color1 red TERRAFORM_ICON 0 '' $terraform_version
+}
+
+_p9k_prompt_terraform_version_init() {
+  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$commands[terraform]'
+}
+
 function prompt_proxy() {
   local -U p=(
     $all_proxy $http_proxy $https_proxy $ftp_proxy

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4888,8 +4888,10 @@ _p9k_prompt_terraform_init() {
 }
 
 function prompt_terraform_version() {
-  local terraform_version="$(command terraform --version)"
-  _p9k_prompt_segment "$0$state" $_p9k_color1 red TERRAFORM_ICON 0 '' $terraform_version
+  _p9k_cached_cmd 0 '' terraform --version
+  [[ $_p9k__ret == (#b)Terraform\ v([[:digit:].]##)* ]]
+  local terraform_version=$match[1]
+  _p9k_prompt_segment "$0$state" $_p9k_color1 red TERRAFORM_ICON 0 '' "tf:$terraform_version"
 }
 
 _p9k_prompt_terraform_version_init() {


### PR DESCRIPTION
* Added new module to shown in the prompt the active terraform version. 
* The terraform version in shown in this format: Terraform v0.12.13 [Terraform Icon]. If only if a valid terraform command is used, or an alias to it.

The use case: We have a need to constantly change between terraform versions depending on what project we are working on, it is easy to upgrade the wrong project to the latest terraform version by mistake. This is why the prompt is shown in red as soon as you type terraform, this is a good way to remind people to double check the correct version of terraform is being used

Future improvements:
Detect current terraform version by checking the terraform workspace state version, and change the terraform color prompt from red to green if you're using the same version. This could be configurable.