### PR TITLE
✨ add availability to show terraform version segment only when terraform files are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ enable as many segments as you like. It won't slow down your prompt or Zsh start
 | `package` | `name@version` from [package.json](https://docs.npmjs.com/files/package.json) |
 | `kubecontext` | current [kubernetes](https://kubernetes.io/) context |
 | `terraform` | [terraform](https://www.terraform.io) workspace |
+| `terraform_version` | [terraform](https://www.terraform.io) version |
 | `aws` | [aws profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) |
 | `aws_eb_env` | [aws elastic beanstalk](https://aws.amazon.com/elasticbeanstalk/) environment |
 | `azure` | [azure](https://docs.microsoft.com/en-us/cli/azure) account name |

--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -1206,6 +1206,8 @@
   # typeset -g POWERLEVEL9K_TERRAFORM_OTHER_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   #############[ terraform_version: terraform version (https://www.terraform.io) ]##############
+  # Don't show terraform version if there is no "*.tf" files
+  typeset -g POWERLEVEL9K_TERRAFORM_VERSION_ALWAYS=false
   # Terraform version color.
   typeset -g POWERLEVEL9K_TERRAFORM_VERSION_FOREGROUND=38
   # Custom icon.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -1274,6 +1274,8 @@
   # typeset -g POWERLEVEL9K_TERRAFORM_OTHER_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   #############[ terraform_version: terraform version (https://www.terraform.io) ]##############
+  # Don't show terraform version if there is no "*.tf" files
+  typeset -g POWERLEVEL9K_TERRAFORM_VERSION_ALWAYS=false
   # Terraform version color.
   typeset -g POWERLEVEL9K_TERRAFORM_VERSION_FOREGROUND=4
   # Custom icon.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -1270,6 +1270,8 @@
   # typeset -g POWERLEVEL9K_TERRAFORM_OTHER_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   #############[ terraform_version: terraform version (https://www.terraform.io) ]##############
+  # Don't show terraform version if there is no "*.tf" files
+  typeset -g POWERLEVEL9K_TERRAFORM_VERSION_ALWAYS=false
   # Terraform version color.
   typeset -g POWERLEVEL9K_TERRAFORM_VERSION_FOREGROUND=38
   # Custom icon.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -1273,6 +1273,8 @@
   # typeset -g POWERLEVEL9K_TERRAFORM_OTHER_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
   #############[ terraform_version: terraform version (https://www.terraform.io) ]##############
+  # Don't show terraform version if there is no "*.tf" files
+  typeset -g POWERLEVEL9K_TERRAFORM_VERSION_ALWAYS=false
   # Terraform version color.
   typeset -g POWERLEVEL9K_TERRAFORM_VERSION_FOREGROUND=4
   typeset -g POWERLEVEL9K_TERRAFORM_VERSION_BACKGROUND=0

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3,7 +3,7 @@ if [[ $__p9k_sourced != 13 ]]; then
   >&2 print -P "[%F{1}ERROR%f]: Corrupted powerlevel10k installation."
   >&2 print -P ""
   if (( ${+functions[antigen]} )); then
-    >&2 print -P "If using %Bantigen%b, run the folowing command to fix:"
+    >&2 print -P "If using %Bantigen%b, run the following command to fix:"
     >&2 print -P ""
     >&2 print -P "    %F{2}antigen%f reset"
     if [[ -d ~/.antigen ]]; then
@@ -4888,6 +4888,9 @@ _p9k_prompt_terraform_init() {
 }
 
 function prompt_terraform_version() {
+  if [[ $_POWERLEVEL9K_TERRAFORM_VERSION_ALWAYS ]]; then
+    _p9k_upglob "*.tf" && return 1
+  fi
   _p9k_cached_cmd 0 '' terraform --version || return
   local v=${_p9k__ret#Terraform v}
   (( $#v < $#_p9k__ret )) || return


### PR DESCRIPTION
- Nowadays, when terrafom_version segment is enabled, the terraform vesion is always prompt.
The purpose of this PR is to show terraform version segment only when terraform files are present in directory (based in pattern *.tf)

- Add  "terraform_version" segment in the doc