### PR TITLE
Add support for AWS_REGION with fallback to AWS_DEFAULT_REGION

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -1168,8 +1168,8 @@ prompt_aws() {
     fi
   done
 
-  if [[ -n $AWS_DEFAULT_REGION ]]; then
-    typeset -g P9K_AWS_REGION=$AWS_DEFAULT_REGION
+  if [[ -n ${AWS_REGION:-AWS_DEFAULT_REGION} ]]; then
+    typeset -g P9K_AWS_REGION=${AWS_REGION:-AWS_DEFAULT_REGION}
   else
     local cfg=${AWS_CONFIG_FILE:-~/.aws/config}
     if ! _p9k_cache_stat_get $0 $cfg; then


### PR DESCRIPTION
v2 of aws-cli still supports setting the region via AWS_REGION, and it has precedence over AWS_DEFAULT_REGION. This should be reflected appropriately in the AWS segment.