### PR TITLE
Add docker_context segment

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -68,6 +68,7 @@
     phpenv                  # php version from phpenv (https://github.com/phpenv/phpenv)
     scalaenv                # scala version from scalaenv (https://github.com/scalaenv/scalaenv)
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
+    docker_context          # current docker context (https://docs.docker.com/engine/context/working-with-contexts/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
     # terraform_version     # terraform version (https://www.terraform.io)
@@ -1211,6 +1212,13 @@
   typeset -g POWERLEVEL9K_TERRAFORM_VERSION_FOREGROUND=38
   # Custom icon.
   # typeset -g POWERLEVEL9K_TERRAFORM_VERSION_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
+  #############[ docker_context: current docker context (https://docs.docker.com/engine/context/working-with-contexts/) ]#############
+  # Show docker context only when the command you are typing invokes one of these (pipe-separated) tools.
+  # Comment the next line to always show docker context.
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_ON_COMMAND='docker'
+  # Don't show docker context if it's literally "default".
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_DEFAULT=false
 
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -68,6 +68,7 @@
     phpenv                  # php version from phpenv (https://github.com/phpenv/phpenv)
     scalaenv                # scala version from scalaenv (https://github.com/scalaenv/scalaenv)
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
+    docker_context          # current docker context (https://docs.docker.com/engine/context/working-with-contexts/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
     # terraform_version     # terraform version (https://www.terraform.io)
@@ -1153,6 +1154,13 @@
   typeset -g POWERLEVEL9K_HASKELL_STACK_ALWAYS_SHOW=true
   # Custom icon.
   # typeset -g POWERLEVEL9K_HASKELL_STACK_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
+  #############[ docker_context: current docker context (https://docs.docker.com/engine/context/working-with-contexts/) ]#############
+  # Show docker context only when the command you are typing invokes one of these (pipe-separated) tools.
+  # Comment the next line to always show docker context.
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_ON_COMMAND='docker'
+  # Don't show docker context if it's literally "default".
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_DEFAULT=false
 
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -68,6 +68,7 @@
     phpenv                  # php version from phpenv (https://github.com/phpenv/phpenv)
     scalaenv                # scala version from scalaenv (https://github.com/scalaenv/scalaenv)
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
+    docker_context          # current docker context (https://docs.docker.com/engine/context/working-with-contexts/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
     # terraform_version     # terraform version (https://www.terraform.io)
@@ -1149,6 +1150,13 @@
   typeset -g POWERLEVEL9K_HASKELL_STACK_ALWAYS_SHOW=true
   # Custom icon.
   # typeset -g POWERLEVEL9K_HASKELL_STACK_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
+  #############[ docker_context: current docker context (https://docs.docker.com/engine/context/working-with-contexts/) ]#############
+  # Show docker context only when the command you are typing invokes one of these (pipe-separated) tools.
+  # Comment the next line to always show docker context.
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_ON_COMMAND='docker'
+  # Don't show docker context if it's literally "default".
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_DEFAULT=false
 
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -68,6 +68,7 @@
     phpenv                  # php version from phpenv (https://github.com/phpenv/phpenv)
     scalaenv                # scala version from scalaenv (https://github.com/scalaenv/scalaenv)
     haskell_stack           # haskell version from stack (https://haskellstack.org/)
+    docker_context          # current docker context (https://docs.docker.com/engine/context/working-with-contexts/)
     kubecontext             # current kubernetes context (https://kubernetes.io/)
     terraform               # terraform workspace (https://www.terraform.io)
     # terraform_version     # terraform version (https://www.terraform.io)
@@ -1282,6 +1283,13 @@
 
   ################[ terraform_version: It shows active terraform version (https://www.terraform.io) ]#################
   typeset -g POWERLEVEL9K_TERRAFORM_VERSION_SHOW_ON_COMMAND='terraform|tf'
+
+  #############[ docker_context: current docker context (https://docs.docker.com/engine/context/working-with-contexts/) ]#############
+  # Show docker context only when the command you are typing invokes one of these (pipe-separated) tools.
+  # Comment the next line to always show docker context.
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_ON_COMMAND='docker'
+  # Don't show docker context if it's literally "default".
+  typeset -g POWERLEVEL9K_DOCKER_CONTEXT_SHOW_DEFAULT=false
 
   #############[ kubecontext: current kubernetes context (https://kubernetes.io/) ]#############
   # Show kubecontext only when the the command you are typing invokes one of these tools.

--- a/internal/icons.zsh
+++ b/internal/icons.zsh
@@ -147,6 +147,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'               # ⬢
+        DOCKER_ICON                    '\U1F433'              # 🐳
       )
     ;;
     'awesome-fontconfig')
@@ -278,6 +279,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'               # ⬢
+        DOCKER_ICON                    '\U1F433'              # 🐳
       )
     ;;
     'awesome-mapped-fontconfig')
@@ -412,6 +414,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'                                       # ⬢
+        DOCKER_ICON                    '\U1F433'                                      # 🐳
       )
     ;;
     'nerdfont-complete'|'nerdfont-fontconfig')
@@ -544,6 +547,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     '\uE624'               # 
         SCALA_ICON                     '\uE737'               # 
         TOOLBOX_ICON                   '\uE20F'$s             # 
+        DOCKER_ICON                    '\U1F433'              # 🐳
       )
     ;;
     ascii)
@@ -673,6 +677,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   'toolbox'
+        DOCKER_ICON                    'docker'
       )
     ;;
     *)
@@ -804,6 +809,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'               # ⬢
+        DOCKER_ICON                    '\U1F433'              # 🐳
       )
     ;;
   esac

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -2131,6 +2131,27 @@ prompt_dir() {
 instant_prompt_dir() { prompt_dir; }
 
 ################################################################
+# Docker context
+prompt_docker_context() {
+  local ctx=${DOCKER_CONTEXT:-default}
+  if [[ -z ${DOCKER_CONTEXT:-} ]]; then
+    if (( $+commands[jq] )); then
+      local cfg=${DOCKER_CONFIG:-~/.docker/config.json}
+      ctx="$(jq -e -r '.currentContext' $cfg 2>/dev/null)" || ctx=default
+    else;
+      ctx=$(docker context show)
+    fi
+  fi
+  [[ -z $ctx || $ctx == default && $_POWERLEVEL9K_DOCKER_CONTEXT_SHOW_DEFAULT == 0 ]] && return
+  _p9k_prompt_segment "$0" "$_p9k_color1" "deepskyblue1" 'DOCKER_ICON' 0 '' "$ctx"
+}
+
+_p9k_prompt_docker_context_init() {
+  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$commands[docker]'
+}
+
+
+################################################################
 # Docker machine
 prompt_docker_machine() {
   _p9k_prompt_segment "$0" "magenta" "$_p9k_color1" 'SERVER_ICON' 0 '' "${DOCKER_MACHINE_NAME//\%/%%}"
@@ -7495,6 +7516,7 @@ _p9k_init_params() {
   _p9k_declare -a POWERLEVEL9K_KUBECONTEXT_CLASSES --
   _p9k_declare -a POWERLEVEL9K_AWS_CLASSES --
   _p9k_declare -a POWERLEVEL9K_AZURE_CLASSES --
+  _p9k_declare -b POWERLEVEL9K_DOCKER_CONTEXT_SHOW_DEFAULT 0
   _p9k_declare -a POWERLEVEL9K_TERRAFORM_CLASSES --
   _p9k_declare -b POWERLEVEL9K_TERRAFORM_SHOW_DEFAULT 0
   _p9k_declare -a POWERLEVEL9K_GOOGLE_APP_CRED_CLASSES -- 'service_account:*' SERVICE_ACCOUNT


### PR DESCRIPTION
Adds docker_context segment to show current docker context, with
SHOW_ON_COMMAND and SHOW_DEFAULT parameters.

I hope submitting a PR for this is ok. I would have commented on the issue first but by the time I'd had a go to see if it seemed doable I was most of the way done!

I'm sure there are ways this could be more performant, any advice would be appreciated. `docker context show` is slow, ~100ms, so this is _much_ faster when `jq` is available. I don't have a windows machine available to test whether it can find the config file ok on there, so that might need work.

Closes #1485