### PR TITLE
Add option for not overriding OS

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -1622,6 +1622,11 @@
   # really need it.
   typeset -g POWERLEVEL9K_DISABLE_HOT_RELOAD=true
 
+  # Prevent the OS variable from being set.
+  # On Windows P10K sets OS to Windows by default, which can create problems for applications
+  # expecting it to be the default Windows_NT. By enabling this option, P10K won't set OS.
+  #typeset -g POWERLEVEL9K_DONT_SET_OS=true
+
   # If p10k is already loaded, reload configuration.
   # This works even with POWERLEVEL9K_DISABLE_HOT_RELOAD=true.
   (( ! $+functions[p10k] )) || p10k reload

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -1603,6 +1603,11 @@
   # really need it.
   typeset -g POWERLEVEL9K_DISABLE_HOT_RELOAD=true
 
+  # Prevent the OS variable from being set.
+  # On Windows P10K sets OS to Windows by default, which can create problems for applications
+  # expecting it to be the default Windows_NT. By enabling this option, P10K won't set OS.
+  #typeset -g POWERLEVEL9K_DONT_SET_OS=true
+
   # If p10k is already loaded, reload configuration.
   # This works even with POWERLEVEL9K_DISABLE_HOT_RELOAD=true.
   (( ! $+functions[p10k] )) || p10k reload

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -1599,6 +1599,11 @@
   # really need it.
   typeset -g POWERLEVEL9K_DISABLE_HOT_RELOAD=true
 
+  # Prevent the OS variable from being set.
+  # On Windows P10K sets OS to Windows by default, which can create problems for applications
+  # expecting it to be the default Windows_NT. By enabling this option, P10K won't set OS.
+  #typeset -g POWERLEVEL9K_DONT_SET_OS=true
+
   # If p10k is already loaded, reload configuration.
   # This works even with POWERLEVEL9K_DISABLE_HOT_RELOAD=true.
   (( ! $+functions[p10k] )) || p10k reload

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -1710,6 +1710,11 @@
   # really need it.
   typeset -g POWERLEVEL9K_DISABLE_HOT_RELOAD=true
 
+  # Prevent the OS variable from being set.
+  # On Windows P10K sets OS to Windows by default, which can create problems for applications
+  # expecting it to be the default Windows_NT. By enabling this option, P10K won't set OS.
+  #typeset -g POWERLEVEL9K_DONT_SET_OS=true
+
   # If p10k is already loaded, reload configuration.
   # This works even with POWERLEVEL9K_DISABLE_HOT_RELOAD=true.
   (( ! $+functions[p10k] )) || p10k reload

--- a/config/p10k-robbyrussell.zsh
+++ b/config/p10k-robbyrussell.zsh
@@ -99,6 +99,11 @@
   # really need it.
   typeset -g POWERLEVEL9K_DISABLE_HOT_RELOAD=true
 
+  # Prevent the OS variable from being set.
+  # On Windows P10K sets OS to Windows by default, which can create problems for applications
+  # expecting it to be the default Windows_NT. By enabling this option, P10K won't set OS.
+  #typeset -g POWERLEVEL9K_DONT_SET_OS=true
+
   # If p10k is already loaded, reload configuration.
   # This works even with POWERLEVEL9K_DISABLE_HOT_RELOAD=true.
   (( ! $+functions[p10k] )) || p10k reload

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -7566,6 +7566,7 @@ _p9k_init_params() {
   _p9k_declare -b POWERLEVEL9K_TIME_UPDATE_ON_COMMAND 0
   # If set to true, time will update every second.
   _p9k_declare -b POWERLEVEL9K_EXPERIMENTAL_TIME_REALTIME 0
+  _p9k_declare -b POWERLEVEL9K_DONT_SET_OS 0
 
   local -i i=1
   while (( i <= $#_POWERLEVEL9K_LEFT_PROMPT_ELEMENTS )); do
@@ -8402,7 +8403,11 @@ function _p9k_init_cacheable() {
   fi
 
   # Someone might be using these.
+  # On Windows OS is already set to Windows_NT,
+  # and setting this to Windows can be problematic
+  if [ $_POWERLEVEL9K_DONT_SET_OS -eq 0 ]; then
   typeset -g OS=$_p9k_os
+  fi
   typeset -g DEFAULT_COLOR=$_p9k_color1
   typeset -g DEFAULT_COLOR_INVERTED=$_p9k_color2
 


### PR DESCRIPTION
Would you consider adding an option for something like this?
I've ran into OS being overridden to 'Windows' being a problem a few times when applications expect 'Windows_NT', and it'd be nice to have an option for not overriding it.

Idk. what the best way to go about it is, so I just hacked together something.
If this is no bueno, but you're not against something like this in principle, let me know how you'd prefer something like this to look and I'll update the MR.