### PR TITLE
Add `arch` prompt for displaying CPU architecture

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -94,6 +94,7 @@
     todo                    # todo items (https://github.com/todotxt/todo.txt-cli)
     timewarrior             # timewarrior tracking status (https://timewarrior.net/)
     taskwarrior             # taskwarrior task count (https://taskwarrior.org/)
+    # arch                  # current CPU Architecture
     # time                  # current time
     # =========================[ Line #2 ]=========================
     newline                 # \n
@@ -1548,6 +1549,10 @@
   #   P9K_WIFI_RSSI         | signal strength in dBm, from -120 to 0
   #   P9K_WIFI_NOISE        | noise in dBm, from -120 to 0
   #   P9K_WIFI_BARS         | signal strength in bars, from 0 to 4 (derived from P9K_WIFI_RSSI and P9K_WIFI_NOISE)
+
+  ##############################[ arch: current cup architecture ]##############################
+  # Default CPU Aricheture (section is hidden when current architecture matches default)
+  # typeset -g POWERLEVEL9K_ARCH_DEFAULT='i386'
 
   ####################################[ time: current time ]####################################
   # Current time color.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -93,6 +93,7 @@
     todo                    # todo items (https://github.com/todotxt/todo.txt-cli)
     timewarrior             # timewarrior tracking status (https://timewarrior.net/)
     taskwarrior             # taskwarrior task count (https://taskwarrior.org/)
+    # arch                  # current CPU Architecture
     # time                  # current time
     # =========================[ Line #2 ]=========================
     newline                 # \n
@@ -1529,6 +1530,10 @@
   #   P9K_WIFI_RSSI         | signal strength in dBm, from -120 to 0
   #   P9K_WIFI_NOISE        | noise in dBm, from -120 to 0
   #   P9K_WIFI_BARS         | signal strength in bars, from 0 to 4 (derived from P9K_WIFI_RSSI and P9K_WIFI_NOISE)
+
+  ##############################[ arch: current cup architecture ]##############################
+  # Default CPU Aricheture (section is hidden when current architecture matches default)
+  # typeset -g POWERLEVEL9K_ARCH_DEFAULT='i386'
 
   ####################################[ time: current time ]####################################
   # Current time color.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -93,6 +93,7 @@
     todo                    # todo items (https://github.com/todotxt/todo.txt-cli)
     timewarrior             # timewarrior tracking status (https://timewarrior.net/)
     taskwarrior             # taskwarrior task count (https://taskwarrior.org/)
+    # arch                  # current CPU Architecture
     # time                  # current time
     # =========================[ Line #2 ]=========================
     newline
@@ -1525,6 +1526,10 @@
   #   P9K_WIFI_RSSI         | signal strength in dBm, from -120 to 0
   #   P9K_WIFI_NOISE        | noise in dBm, from -120 to 0
   #   P9K_WIFI_BARS         | signal strength in bars, from 0 to 4 (derived from P9K_WIFI_RSSI and P9K_WIFI_NOISE)
+
+  ##############################[ arch: current cup architecture ]##############################
+  # Default CPU Aricheture (section is hidden when current architecture matches default)
+  # typeset -g POWERLEVEL9K_ARCH_DEFAULT='i386'
 
   ####################################[ time: current time ]####################################
   # Current time color.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -94,6 +94,7 @@
     todo                    # todo items (https://github.com/todotxt/todo.txt-cli)
     timewarrior             # timewarrior tracking status (https://timewarrior.net/)
     taskwarrior             # taskwarrior task count (https://taskwarrior.org/)
+    # arch                  # current CPU Architecture
     # time                  # current time
     # =========================[ Line #2 ]=========================
     newline
@@ -1633,6 +1634,10 @@
   #   P9K_WIFI_RSSI         | signal strength in dBm, from -120 to 0
   #   P9K_WIFI_NOISE        | noise in dBm, from -120 to 0
   #   P9K_WIFI_BARS         | signal strength in bars, from 0 to 4 (derived from P9K_WIFI_RSSI and P9K_WIFI_NOISE)
+
+  ##############################[ arch: current cup architecture ]##############################
+  # Default CPU Aricheture (section is hidden when current architecture matches default)
+  # typeset -g POWERLEVEL9K_ARCH_DEFAULT='i386'
 
   ####################################[ time: current time ]####################################
   # Current time color.

--- a/internal/icons.zsh
+++ b/internal/icons.zsh
@@ -148,6 +148,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'               # ⬢
+        ARCH_ICON                      '\uE205'               # 
       )
     ;;
     'awesome-fontconfig')
@@ -280,6 +281,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'               # ⬢
+        ARCH_ICON                      '\uE205'               # 
       )
     ;;
     'awesome-mapped-fontconfig')
@@ -415,6 +417,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'                                       # ⬢
+        ARCH_ICON                      '\uE205'                                       # 
       )
     ;;
     'nerdfont-complete'|'nerdfont-fontconfig')
@@ -548,6 +551,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     '\uE624'               # 
         SCALA_ICON                     '\uE737'               # 
         TOOLBOX_ICON                   '\uE20F'$s             # 
+        ARCH_ICON                      '\uE266'
       )
     ;;
     ascii)
@@ -810,6 +814,7 @@ function _p9k_init_icons() {
         JULIA_ICON                     'jl'
         SCALA_ICON                     'scala'
         TOOLBOX_ICON                   '\u2B22'               # ⬢
+        ARCH_ICON                      '\uE205'               # 
       )
     ;;
   esac

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5632,7 +5632,7 @@ prompt_arch() {
     _p9k_cache_ephemeral_set $(arch)
   fi
   [[ $_p9k__cache_val[1] == $POWERLEVEL9K_ARCH_DEFAULT ]] && return
-  _p9k_prompt_segment "$0" "orange1" "black" 'ARCH_ICON' 0 '' "$_p9k__cache_val[1]"
+  _p9k_prompt_segment "$0" "$_p9k_color1" "orange1" 'ARCH_ICON' 0 '' "$_p9k__cache_val[1]"
 }
 
 _p9k_prompt_arch_init() {

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5625,6 +5625,21 @@ _p9k_prompt_haskell_stack_init() {
   typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$commands[stack]'
 }
 
+################################################################
+# CPU Architecture
+prompt_arch() {
+  if ! _p9k_cache_ephemeral_get $0 ; then
+    _p9k_cache_ephemeral_set $(arch)
+  fi
+  [[ $_p9k__cache_val[1] == $POWERLEVEL9K_ARCH_DEFAULT ]] && return
+  _p9k_prompt_segment "$0" "orange1" "black" 'ARCH_ICON' 0 '' "$_p9k__cache_val[1]"
+}
+
+_p9k_prompt_arch_init() {
+  echo 'arch init' >> ~/p9k_debug.txt
+  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$commands[arch]'
+}
+
 # Use two preexec hooks to survive https://github.com/MichaelAquilina/zsh-you-should-use with
 # YSU_HARDCORE=1. See https://github.com/romkatv/powerlevel10k/issues/427.
 _p9k_preexec1() {

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5635,6 +5635,8 @@ prompt_arch() {
   _p9k_prompt_segment "$0" "$_p9k_color1" "orange1" 'ARCH_ICON' 0 '' "$_p9k__cache_val[1]"
 }
 
+instant_prompt_arch() { prompt_arch; }
+
 _p9k_prompt_arch_init() {
   echo 'arch init' >> ~/p9k_debug.txt
   typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$commands[arch]'


### PR DESCRIPTION
Adds the `arch` prompt to `p10k.zsh`, `ARCH_ICON` to `icons.zsh`, and commented entries in the default configs.

Displaying the current CPU architecture is useful on systems where shells may be opened under emulation.  For example, ZSH is commonly run using Rosetta on M1-based macs to emulate i386/x86_64 systems.

Users can optionally set `POWERLEVEL9K_ARCH_DEFAULT` to hide the prompt in shells running under the default system architecture.

![Screen Shot 2022-02-02 at 5 55 38 PM](https://user-images.githubusercontent.com/72231013/152268530-6aaaaaa8-ed03-439b-8a61-26c49172f0de.png)

