### PR TITLE
use $HOST for distrobox detection

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -8280,7 +8280,7 @@ _p9k_init_toolbox() {
     local name=(${(Q)${${(@M)${(f)"$(</run/.containerenv)"}:#name=*}#name=}})
     [[ ${#name} -eq 1 && -n ${name[1]} ]] || return 0
     typeset -g P9K_TOOLBOX_NAME=${name[1]}
-  elif [[ -n $DISTROBOX_ENTER_PATH && -n $NAME ]]; then
+  elif [[ -n $DISTROBOX_ENTER_PATH && -n $HOST ]]; then
     local name=${(%):-%m}
     if [[ $name == $NAME* ]]; then
       typeset -g P9K_TOOLBOX_NAME=$name


### PR DESCRIPTION
`$NAME` empty, use `$HOST` instead ([ZSH builtin env var](https://zsh.sourceforge.io/Doc/Release/Parameters.html#index-HOST))

See issue here for more details: #1915 