### PR TITLE
Add Zi plugin manager to the install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Powerlevel10k.
 - [Zgen](#zgen)
 - [Zplugin](#zplugin)
 - [Zinit](#zinit)
+- [Zi](#zi)
 - [Homebrew](#homebrew)
 - [Arch Linux](#arch-linux)
 - [Alpine Linux](#arch-linux)
@@ -485,6 +486,12 @@ Add `zinit ice depth=1; zinit light romkatv/powerlevel10k` to `~/.zshrc`.
 
 The use of `depth=1` ice is optional. Other types of ice are neither recommended nor officially
 supported by Powerlevel10k.
+
+### ZI
+
+Add `zi ice depth=1; zi light romkatv/powerlevel10k` to `~/.zshrc`.
+
+See [wiki.zshell.dev](https://wiki.zshell.dev/community/gallery/collection/themes#thp-romkatvpowerlevel10k) for more
 
 ### Homebrew
 
@@ -811,8 +818,9 @@ The command to update Powerlevel10k depends on how it was installed.
 | [Zgen](#zgen)                 | `zgen update`                                               |
 | [Zplugin](#zplugin)           | `zplugin update`                                            |
 | [Zinit](#zinit)               | `zinit update`                                              |
+| [Zi](#zi)                     | `zi update`                                                 |
 | [Homebrew](#homebrew)         | `brew update && brew upgrade`                               |
-| [Arch Linux](#arch-linux)     | `yay -S --noconfirm zsh-theme-powerlevel10k-git`            |
+| [Arch Linux](#arch-linux)     | `yay -S --noconfirm zsh-theme-powerlevel10k-git`             |
 | [Alpine Linux](#alpine-linux) | `apk update && apk upgrade`                                 |
 
 **IMPORTANT**: Restart Zsh after updating Powerlevel10k. [Do not use `source ~/.zshrc`](
@@ -862,8 +870,9 @@ The command to update Powerlevel10k depends on how it was installed.
    | [Zgen](#zgen)                 | `zgen reset`                                                     |
    | [Zplugin](#zplugin)           | `zplugin delete romkatv/powerlevel10k`                           |
    | [Zinit](#zinit)               | `zinit delete romkatv/powerlevel10k`                             |
+   | [Zi](#zi)                     | `zi delete romkatv/powerlevel10k`                                |
    | [Homebrew](#homebrew)         | `brew uninstall powerlevel10k; brew untap romkatv/powerlevel10k` |
-   | [Arch Linux](#arch-linux)     | `yay -R --noconfirm zsh-theme-powerlevel10k-git`                 |
+   | [Arch Linux](#arch-linux)     | `yay -R --noconfirm zsh-theme-powerlevel10k-git`                  |
    | [Alpine Linux](#alpine-linux) | `apk del zsh-theme-powerlevel10k`                                |
 6. Restart Zsh. [Do not use `source ~/.zshrc`](#weird-things-happen-after-typing-source-zshrc).
 7. Delete Powerlevel10k cache files.


### PR DESCRIPTION
A more detailled procedure of the installation of powerlevel10k with zi is available at [wiki.zshell.dev](https://wiki.zshell.dev/community/gallery/collection/themes#thp-romkatvpowerlevel10k)

---
[ZI](https://wiki.zshell.dev): [https://wiki.zshell.dev/](https://wiki.zshell.dev/)
[ZI](https://wiki.zshell.dev) + [PowerLevel10k](https://github.com/romkatv/powerlevel10k): [https://wiki.zshell.dev/community/gallery/collection/themes#thp-romkatvpowerlevel10k](https://wiki.zshell.dev/community/gallery/collection/themes#thp-romkatvpowerlevel10k)