### PR TITLE
add support for poetry virtualenv

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -47,6 +47,7 @@
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)
     anaconda                # conda environment (https://conda.io/)
     pyenv                   # python environment (https://github.com/pyenv/pyenv)
+    poetry                  # python poetry (https://python-poetry.org/)
     goenv                   # go environment (https://github.com/syndbg/goenv)
     nodenv                  # node.js version from nodenv (https://github.com/nodenv/nodenv)
     nvm                     # node.js version from nvm (https://github.com/nvm-sh/nvm)
@@ -892,6 +893,10 @@
   # If set to "false", won't show virtualenv if pyenv is already shown.
   # If set to "if-different", won't show virtualenv if it's the same as pyenv.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_PYENV=false
+  # If set to "true", get the virtualenv from poetry if available
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_POETRY=false
+  # Show poetry venv only when in a directory tree containing pyproject.toml.
+  typeset -g POWERLEVEL9K_POETRY_VENV_PROJECT_ONLY=true
   # Separate environment name from Python version only with a space.
   typeset -g POWERLEVEL9K_VIRTUALENV_{LEFT,RIGHT}_DELIMITER=
   # Custom icon.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -47,6 +47,7 @@
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)
     anaconda                # conda environment (https://conda.io/)
     pyenv                   # python environment (https://github.com/pyenv/pyenv)
+    poetry                  # python poetry (https://python-poetry.org/)
     goenv                   # go environment (https://github.com/syndbg/goenv)
     nodenv                  # node.js version from nodenv (https://github.com/nodenv/nodenv)
     nvm                     # node.js version from nvm (https://github.com/nvm-sh/nvm)
@@ -873,6 +874,10 @@
   # If set to "false", won't show virtualenv if pyenv is already shown.
   # If set to "if-different", won't show virtualenv if it's the same as pyenv.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_PYENV=false
+  # If set to "true", get the virtualenv from poetry if available
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_POETRY=false
+  # Show poetry venv only when in a directory tree containing pyproject.toml.
+  typeset -g POWERLEVEL9K_POETRY_VENV_PROJECT_ONLY=true
   # Separate environment name from Python version only with a space.
   typeset -g POWERLEVEL9K_VIRTUALENV_{LEFT,RIGHT}_DELIMITER=
   # Custom icon.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -47,6 +47,7 @@
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)
     anaconda                # conda environment (https://conda.io/)
     pyenv                   # python environment (https://github.com/pyenv/pyenv)
+    poetry                  # python poetry (https://python-poetry.org/)
     goenv                   # go environment (https://github.com/syndbg/goenv)
     nodenv                  # node.js version from nodenv (https://github.com/nodenv/nodenv)
     nvm                     # node.js version from nvm (https://github.com/nvm-sh/nvm)
@@ -869,6 +870,10 @@
   # If set to "false", won't show virtualenv if pyenv is already shown.
   # If set to "if-different", won't show virtualenv if it's the same as pyenv.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_PYENV=false
+  # If set to "true", get the virtualenv from poetry if available
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_POETRY=false
+  # Show poetry venv only when in a directory tree containing pyproject.toml.
+  typeset -g POWERLEVEL9K_POETRY_VENV_PROJECT_ONLY=true
   # Separate environment name from Python version only with a space.
   typeset -g POWERLEVEL9K_VIRTUALENV_{LEFT,RIGHT}_DELIMITER=
   # Custom icon.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -47,6 +47,7 @@
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)
     anaconda                # conda environment (https://conda.io/)
     pyenv                   # python environment (https://github.com/pyenv/pyenv)
+    poetry                  # python poetry (https://python-poetry.org/)
     goenv                   # go environment (https://github.com/syndbg/goenv)
     nodenv                  # node.js version from nodenv (https://github.com/nodenv/nodenv)
     nvm                     # node.js version from nvm (https://github.com/nvm-sh/nvm)
@@ -931,6 +932,10 @@
   # If set to "false", won't show virtualenv if pyenv is already shown.
   # If set to "if-different", won't show virtualenv if it's the same as pyenv.
   typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_PYENV=false
+  # If set to "true", get the virtualenv from poetry if available
+  typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_POETRY=false
+  # Show poetry venv only when in a directory tree containing pyproject.toml.
+  typeset -g POWERLEVEL9K_POETRY_VENV_PROJECT_ONLY=true
   # Separate environment name from Python version only with a space.
   typeset -g POWERLEVEL9K_VIRTUALENV_{LEFT,RIGHT}_DELIMITER=
   # Custom icon.

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4236,6 +4236,44 @@ instant_prompt_vi_mode() {
 }
 
 ################################################################
+# Segment to display poetry virtualenv information
+# https://python-poetry.org/
+prompt_poetry() {
+  local msg=''
+  if (( _POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION )) && _p9k_python_version; then
+    msg="${_p9k__ret//\%/%%} "
+  fi
+  _p9k_poetry_compute || return
+  msg+="$P9K_POETRY_PYTHON_VENV"
+  _p9k_prompt_segment "$0" "blue" "$_p9k_color1" 'PYTHON_ICON' 0 '' "$msg"
+}
+
+_p9k_prompt_poetry_init() {
+  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='${commands[poetry]:-${${+functions[poetry]}:#0}}'
+}
+
+function _p9k_poetry_compute() {
+  unset P9K_POETRY_PYTHON_VENV
+  case $_POWERLEVEL9K_VIRTUALENV_SHOW_WITH_POETRY in
+    true)
+      _p9k_upglob pyproject.toml
+      local idx=$?
+      if (( idx == 1 )); then
+        _p9k_cached_cmd 0 $_p9k__parent_dirs[idx]/pyproject.toml poetry env info -p || return
+      elif (( idx > 1 )); then
+        (( _POWERLEVEL9K_POETRY_VENV_PROJECT_ONLY )) && return
+        _p9k_cached_cmd 0 '' poetry env info -p || return
+      fi
+      if [[ $_p9k__ret == (#b)*/([^/]##) ]]; then
+        typeset -g P9K_POETRY_PYTHON_VENV=$match[1]
+        return
+      fi
+    ;;
+  esac
+  return 1
+}
+
+################################################################
 # Virtualenv: current working virtualenv
 # More information on virtualenv (Python):
 # https://virtualenv.pypa.io/en/latest/


### PR DESCRIPTION
Hi,

Here is a little patch in order to support [poetry](https://python-poetry.org/) when looking for a project virtualenv.

This change adds two configuration variables:
```
# If set to "true", get the virtualenv from poetry if available
typeset -g POWERLEVEL9K_VIRTUALENV_SHOW_WITH_POETRY=false
# Show poetry venv only when in a directory tree containing pyproject.toml.
typeset -g POWERLEVEL9K_POETRY_VENV_PROJECT_ONLY=true
```