### PR TITLE
Update Windows Terminal font configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,11 +647,21 @@ If you are using a different terminal, proceed with manual font installation. �
      *Custom font* under *Text Appearance* and select `MesloLGS NF Regular`.
    - **Windows Console Host** (the old thing): Click the icon in the top left corner, then
      *Properties → Font* and set *Font* to `MesloLGS NF`.
-   - **Windows Terminal** by Microsoft (the new thing): Open `settings.json` (<kbd>Ctrl+Shift+,</kbd>),
-     search for `fontFace` and set the value to `MesloLGS NF` for every profile. If you don't find
-     `fontFace`, add it under *profiles → defaults*. See [this settings file](
-       https://raw.githubusercontent.com/romkatv/dotfiles-public/aba0e6c4657d705ed6c344d700d659977385f25c/dotfiles/microsoft-terminal-settings.json)
+   - **Windows Terminal** by Microsoft (the new thing): Open `settings.json` (<kbd>Ctrl+,</kbd>),
+     search for `font.face` and set the value to `MesloLGS NF` for every profile. If you don't find
+     `font.face`, add it under *profiles → defaults*. See [this settings file](
+       https://raw.githubusercontent.com/romkatv/dotfiles-public/1843af92dbd8f6297de195a469362760e1748f58/dotfiles/microsoft-terminal-settings.json)
      for example.
+     ```json
+     {
+      "profiles": {
+        "defaults": {
+          "font": {
+            "face": "MesloLGS NF"
+          }
+        }
+     }
+     ```
    - **IntelliJ** (and other IDEs by Jet Brains): Open *IDE → Edit → Preferences → Editor →
      Color Scheme → Console Font*. Select *Use console font instead of the default* and set the font
      name to `MesloLGS NF`.


### PR DESCRIPTION
- Change the deprecated `fontFace` to [`font.face`](https://docs.microsoft.com/en-gb/windows/terminal/customize-settings/profile-appearance#font-face)
- Update the settings shortcut from <kbd>Ctrl+Shift+,</kbd> to <kbd>Ctrl+,</kbd>
- Change the example settings link to point to the latest commit of the same file which uses the new `font.face`
- Add inline example