### PR TITLE
Add VCS commit ahead/behind count with push remote

### DIFF
--- a/internal/icons.zsh
+++ b/internal/icons.zsh
@@ -91,6 +91,8 @@ function _p9k_init_icons() {
         #VCS_OUTGOING_CHANGES_ICON     '\uE1EC '              # 
         #VCS_OUTGOING_CHANGES_ICON     '\uE80E '              # 
         VCS_OUTGOING_CHANGES_ICON      '\uE132 '              # 
+        VCS_PUSH_INCOMING_CHANGES_ICON '\uE283 '              # 
+        VCS_PUSH_OUTGOING_CHANGES_ICON '\uE282 '              # 
         VCS_TAG_ICON                   '\uE817 '              # 
         VCS_BOOKMARK_ICON              '\uE87B'               # 
         VCS_COMMIT_ICON                '\uE821 '              # 
@@ -223,6 +225,8 @@ function _p9k_init_icons() {
         VCS_STASH_ICON                 '\uF01C '              # 
         VCS_INCOMING_CHANGES_ICON      '\uF01A '              # 
         VCS_OUTGOING_CHANGES_ICON      '\uF01B '              # 
+        VCS_PUSH_INCOMING_CHANGES_ICON '\uF190 '              # 
+        VCS_PUSH_OUTGOING_CHANGES_ICON '\uF18E '              # 
         VCS_TAG_ICON                   '\uF217 '              # 
         VCS_BOOKMARK_ICON              '\uF27B '              # 
         VCS_COMMIT_ICON                '\uF221 '              # 
@@ -360,6 +364,8 @@ function _p9k_init_icons() {
         VCS_STASH_ICON                 "${CODEPOINT_OF_AWESOME_INBOX:+\\u$CODEPOINT_OF_AWESOME_INBOX }"
         VCS_INCOMING_CHANGES_ICON      "${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_DOWN:+\\u$CODEPOINT_OF_AWESOME_ARROW_CIRCLE_DOWN }"
         VCS_OUTGOING_CHANGES_ICON      "${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_UP:+\\u$CODEPOINT_OF_AWESOME_ARROW_CIRCLE_UP }"
+        VCS_PUSH_INCOMING_CHANGES_ICON "${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_LEFT:+\\u$CODEPOINT_OF_AWESOME_ARROW_CIRCLE_LEFT }"
+        VCS_PUSH_OUTGOING_CHANGES_ICON "${CODEPOINT_OF_AWESOME_ARROW_CIRCLE_RIGHT:+\\u$CODEPOINT_OF_AWESOME_ARROW_CIRCLE_RIGHT }"
         VCS_TAG_ICON                   "${CODEPOINT_OF_AWESOME_TAG:+\\u$CODEPOINT_OF_AWESOME_TAG }"
         VCS_BOOKMARK_ICON              "${CODEPOINT_OF_OCTICONS_BOOKMARK:+\\u$CODEPOINT_OF_OCTICONS_BOOKMARK}"
         VCS_COMMIT_ICON                "${CODEPOINT_OF_OCTICONS_GIT_COMMIT:+\\u$CODEPOINT_OF_OCTICONS_GIT_COMMIT }"
@@ -491,6 +497,8 @@ function _p9k_init_icons() {
         VCS_STASH_ICON                 '\uF01C '              # 
         VCS_INCOMING_CHANGES_ICON      '\uF01A '              # 
         VCS_OUTGOING_CHANGES_ICON      '\uF01B '              # 
+        VCS_PUSH_INCOMING_CHANGES_ICON '\uF190 '              # 
+        VCS_PUSH_OUTGOING_CHANGES_ICON '\uF18E '              # 
         VCS_TAG_ICON                   '\uF02B '              # 
         VCS_BOOKMARK_ICON              '\uF461 '              # 
         VCS_COMMIT_ICON                '\uE729 '              # 
@@ -621,6 +629,8 @@ function _p9k_init_icons() {
         VCS_STASH_ICON                 '#'
         VCS_INCOMING_CHANGES_ICON      '<'
         VCS_OUTGOING_CHANGES_ICON      '>'
+        VCS_PUSH_INCOMING_CHANGES_ICON 'v'
+        VCS_PUSH_OUTGOING_CHANGES_ICON '^'
         VCS_TAG_ICON                   ''
         VCS_BOOKMARK_ICON              '^'
         VCS_COMMIT_ICON                '@'
@@ -753,6 +763,8 @@ function _p9k_init_icons() {
         VCS_STASH_ICON                 '\u235F'               # ⍟
         VCS_INCOMING_CHANGES_ICON      '\u2193'               # ↓
         VCS_OUTGOING_CHANGES_ICON      '\u2191'               # ↑
+        VCS_PUSH_INCOMING_CHANGES_ICON '\u2190'               # ←
+        VCS_PUSH_OUTGOING_CHANGES_ICON '\u2192'               # →
         VCS_TAG_ICON                   ''
         VCS_BOOKMARK_ICON              '\u263F'               # ☿
         VCS_COMMIT_ICON                ''

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3614,6 +3614,12 @@ function +vi-git-aheadbehind() {
   behind="$(git rev-list --count HEAD.."${hook_com[branch]}"@{upstream} 2>/dev/null)"
   (( behind )) && gitstatus+=( " $(print_icon 'VCS_INCOMING_CHANGES_ICON')${behind// /}" )
 
+  push_ahead="$(git rev-list --count "${hook_com[branch]}"@{push}..HEAD 2>/dev/null)"
+  (( push_ahead )) && gitstatus+=( " $(print_icon 'VCS_PUSH_OUTGOING_CHANGES_ICON')${push_ahead// /}" )
+
+  push_behind="$(git rev-list --count HEAD.."${hook_com[branch]}"@{push} 2>/dev/null)"
+  (( push_behind )) && gitstatus+=( " $(print_icon 'VCS_PUSH_INCOMING_CHANGES_ICON')${push_behind// /}" )
+
   hook_com[misc]+=${(j::)gitstatus}
 }
 
@@ -3890,7 +3896,7 @@ function _p9k_vcs_render() {
   fi
 
   (( ${_POWERLEVEL9K_VCS_GIT_HOOKS[(I)git-untracked]} )) || VCS_STATUS_HAS_UNTRACKED=0
-  (( ${_POWERLEVEL9K_VCS_GIT_HOOKS[(I)git-aheadbehind]} )) || { VCS_STATUS_COMMITS_AHEAD=0 && VCS_STATUS_COMMITS_BEHIND=0 }
+  (( ${_POWERLEVEL9K_VCS_GIT_HOOKS[(I)git-aheadbehind]} )) || { VCS_STATUS_COMMITS_AHEAD=0 && VCS_STATUS_COMMITS_BEHIND=0 && VCS_STATUS_PUSH_COMMITS_BEHIND=0 && VCS_STATUS_PUSH_COMMITS_AHEAD=0 }
   (( ${_POWERLEVEL9K_VCS_GIT_HOOKS[(I)git-stash]} )) || VCS_STATUS_STASHES=0
   (( ${_POWERLEVEL9K_VCS_GIT_HOOKS[(I)git-remotebranch]} )) || VCS_STATUS_REMOTE_BRANCH=""
   (( ${_POWERLEVEL9K_VCS_GIT_HOOKS[(I)git-tagname]} )) || VCS_STATUS_TAG=""
@@ -3900,6 +3906,12 @@ function _p9k_vcs_render() {
 
   (( _POWERLEVEL9K_VCS_COMMITS_BEHIND_MAX_NUM >= 0 && VCS_STATUS_COMMITS_BEHIND > _POWERLEVEL9K_VCS_COMMITS_BEHIND_MAX_NUM )) &&
     VCS_STATUS_COMMITS_BEHIND=$_POWERLEVEL9K_VCS_COMMITS_BEHIND_MAX_NUM
+
+  (( _POWERLEVEL9K_VCS_COMMITS_AHEAD_MAX_NUM >= 0 && VCS_STATUS_PUSH_COMMITS_AHEAD > _POWERLEVEL9K_VCS_COMMITS_AHEAD_MAX_NUM )) &&
+    VCS_STATUS_PUSH_COMMITS_AHEAD=$_POWERLEVEL9K_VCS_COMMITS_AHEAD_MAX_NUM
+
+  (( _POWERLEVEL9K_VCS_COMMITS_BEHIND_MAX_NUM >= 0 && VCS_STATUS_PUSH_COMMITS_BEHIND > _POWERLEVEL9K_VCS_COMMITS_BEHIND_MAX_NUM )) &&
+    VCS_STATUS_PUSH_COMMITS_BEHIND=$_POWERLEVEL9K_VCS_COMMITS_BEHIND_MAX_NUM
 
   local -a cache_key=(
     "$VCS_STATUS_LOCAL_BRANCH"
@@ -3915,6 +3927,8 @@ function _p9k_vcs_render() {
     "$VCS_STATUS_HAS_UNTRACKED"
     "$VCS_STATUS_COMMITS_AHEAD"
     "$VCS_STATUS_COMMITS_BEHIND"
+    "$VCS_STATUS_PUSH_COMMITS_AHEAD"
+    "$VCS_STATUS_PUSH_COMMITS_BEHIND"
     "$VCS_STATUS_STASHES"
     "$VCS_STATUS_TAG"
     "$VCS_STATUS_NUM_UNSTAGED_DELETED"
@@ -4018,6 +4032,16 @@ function _p9k_vcs_render() {
         _p9k_get_icon prompt_vcs_$state VCS_OUTGOING_CHANGES_ICON
         (( _POWERLEVEL9K_VCS_COMMITS_AHEAD_MAX_NUM != 1 )) && _p9k__ret+=$VCS_STATUS_COMMITS_AHEAD
         _$0_fmt OUTGOING_CHANGES " $_p9k__ret"
+      fi
+      if [[ $VCS_STATUS_PUSH_COMMITS_BEHIND -gt 0 ]]; then
+        _p9k_get_icon prompt_vcs_$state VCS_PUSH_INCOMING_CHANGES_ICON
+        (( _POWERLEVEL9K_VCS_COMMITS_BEHIND_MAX_NUM != 1 )) && _p9k__ret+=$VCS_STATUS_PUSH_COMMITS_BEHIND
+        _$0_fmt PUSH_INCOMING_CHANGES " $_p9k__ret"
+      fi
+      if [[ $VCS_STATUS_PUSH_COMMITS_AHEAD -gt 0 ]]; then
+        _p9k_get_icon prompt_vcs_$state VCS_PUSH_OUTGOING_CHANGES_ICON
+        (( _POWERLEVEL9K_VCS_COMMITS_AHEAD_MAX_NUM != 1 )) && _p9k__ret+=$VCS_STATUS_PUSH_COMMITS_AHEAD
+        _$0_fmt PUSH_OUTGOING_CHANGES " $_p9k__ret"
       fi
       if [[ $VCS_STATUS_STASHES -gt 0 ]]; then
         _p9k_get_icon prompt_vcs_$state VCS_STASH_ICON


### PR DESCRIPTION
### Context

Follows https://github.com/romkatv/powerlevel10k/issues/2014#issuecomment-1243444257. The user needs to define a function `my_git_formatter` and set:

```bash
# Disable the default Git status formatting.
typeset -g POWERLEVEL9K_VCS_DISABLE_GITSTATUS_FORMATTING=true
# Install our own Git status formatter.
typeset -g POWERLEVEL9K_VCS_CONTENT_EXPANSION='${$((my_git_formatter()))+${my_git_format}}'
```

Although `p10k configure` can generate a template of `my_git_formatter`, it is lack nerd font support:

![image](https://user-images.githubusercontent.com/16078332/189661902-2b4b6747-a505-447f-b10b-279e9af928ea.png)


https://github.com/romkatv/powerlevel10k/blob/4bbb198a606b69dfb2d86ac33686e3d41f6d0141/config/p10k-rainbow.zsh#L361-L458

Icons are hardcoded in the function definition. Maybe we can change these to `print_icon <icon name>`?

------

### Changes

In this PR:

1. Add the ahead/behind count of both `{upstream}` and `{push}` by default in the VSC segment. Even if the user set `typeset -g POWERLEVEL9K_VCS_DISABLE_GITSTATUS_FORMATTING=`.
2. Add the corresponding icons.

![image](https://user-images.githubusercontent.com/16078332/189662014-25cf5a10-1083-4448-9292-6bbd6fcb96d0.png)
