### PR TITLE
Add chruby config to hide RUBY_ENGINE when "ruby"

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3139,7 +3139,9 @@ _p9k_prompt_perlbrew_init() {
 # see https://github.com/postmodern/chruby/issues/245 for chruby_auto issue with ZSH
 prompt_chruby() {
   local v
-  (( _POWERLEVEL9K_CHRUBY_SHOW_ENGINE )) && v=$RUBY_ENGINE
+  if (( _POWERLEVEL9K_CHRUBY_SHOW_ENGINE )) && [[ "$RUBY_ENGINE" != "ruby" || $_POWERLEVEL9K_CHRUBY_SHOW_ENGINE_IF_RUBY == 1 ]]; then
+    v=$RUBY_ENGINE
+  fi
   if [[ $_POWERLEVEL9K_CHRUBY_SHOW_VERSION == 1 && -n $RUBY_VERSION ]] && v+=${v:+ }$RUBY_VERSION
   _p9k_prompt_segment "$0" "red" "$_p9k_color1" 'RUBY_ICON' 0 '' "${v//\%/%%}"
 }
@@ -7534,6 +7536,7 @@ _p9k_init_params() {
   _p9k_declare -b POWERLEVEL9K_RVM_SHOW_PREFIX 0
   _p9k_declare -b POWERLEVEL9K_CHRUBY_SHOW_VERSION 1
   _p9k_declare -b POWERLEVEL9K_CHRUBY_SHOW_ENGINE 1
+  _p9k_declare -b POWERLEVEL9K_CHRUBY_SHOW_ENGINE_IF_RUBY 1
   _p9k_declare -b POWERLEVEL9K_STATUS_CROSS 0
   _p9k_declare -b POWERLEVEL9K_STATUS_OK 1
   _p9k_declare -b POWERLEVEL9K_STATUS_OK_PIPE 1


### PR DESCRIPTION
Previously, the chruby segment looks like this for standard and
non-standard ruby implementations respectively:

```
Ruby ruby 3.1.2
Ruby truffleruby 3.0.3
```

While displaying the RUBY_ENGINE is helpful for non-standard
implementations, showing it for "ruby" results in "Ruby ruby" which
feels redundant.

This commit adds a new configuration option to disable showing the
RUBY_ENGINE when it is "ruby". Other values for RUBY_ENGINE will always
display as before:

```
Ruby 3.1.2
Ruby truffleruby 3.0.3
```

This also makes the formatting more similar to the asdf segment:

```
Ruby 3.1.2
Ruby truffleruby-22.3.0
```