### PR TITLE
Prefer `ip` over `ifconfig` for interface detection.

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5721,19 +5721,19 @@ function _p9k_prompt_net_iface_async() {
   # netstat -inbI en0
   local iface ip line var
   typeset -a iface2ip ips ifaces
-  if (( $+commands[ifconfig] )); then
-    for line in ${(f)"$(command ifconfig 2>/dev/null)"}; do
-      if [[ $line == (#b)([^[:space:]]##):[[:space:]]##flags=([[:xdigit:]]##)'<'* ]]; then
-        [[ $match[2] == *[13579bdfBDF] ]] && iface=$match[1] || iface=
+  if (( $+commands[ip] )); then
+    for line in ${(f)"$(command ip -4 a show 2>/dev/null)"}; do
+      if [[ $line == (#b)<->:[[:space:]]##([^:]##):[[:space:]]##\<([^\>]#)\>* ]]; then
+        [[ ,$match[2], == *,UP,* ]] && iface=$match[1] || iface=
       elif [[ -n $iface && $line == (#b)[[:space:]]##inet[[:space:]]##([0-9.]##)* ]]; then
         iface2ip+=($iface $match[1])
         iface=
       fi
     done
-  elif (( $+commands[ip] )); then
-    for line in ${(f)"$(command ip -4 a show 2>/dev/null)"}; do
-      if [[ $line == (#b)<->:[[:space:]]##([^:]##):[[:space:]]##\<([^\>]#)\>* ]]; then
-        [[ ,$match[2], == *,UP,* ]] && iface=$match[1] || iface=
+  elif (( $+commands[ifconfig] )); then
+    for line in ${(f)"$(command ifconfig 2>/dev/null)"}; do
+      if [[ $line == (#b)([^[:space:]]##):[[:space:]]##flags=([[:xdigit:]]##)'<'* ]]; then
+        [[ $match[2] == *[13579bdfBDF] ]] && iface=$match[1] || iface=
       elif [[ -n $iface && $line == (#b)[[:space:]]##inet[[:space:]]##([0-9.]##)* ]]; then
         iface2ip+=($iface $match[1])
         iface=


### PR DESCRIPTION
`ifconfig`'s formatting doesn't cope well with long interface names. In these cases it will eat up the whitespace separating the name from the text "Link" in the output, which makes parsing the output problematic.

e.g. `ifconfig`:

    wlp0s20f0u2Link encap:Ethernet  HWaddr 00:AA:BB:CC:DD:EE

v.s `ip`:

   21: wlp0s20f0u2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc \
       mq state UP group default qlen 1000

This commit swaps the order of detection inside
`_p9k_prompt_net_iface_async()`, so that `ip` will be preferred.

`ifconfig` is deprecated by distros in favour of `ip`, so this will often be an incredibly marginal performance boost :)

NOTE: this commit does not address the problem with using `ifconfig`. I don't understand the zsh regex, so have not touched it.