### PR TITLE
Display specific architecture on macOS

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5656,7 +5656,9 @@ prompt_cpu_arch() {
     state=$_p9k__cache_val[1]
     text=$_p9k__cache_val[2]
   else
-    text=$(command arch) 2>/dev/null && [[ $text == [a-zA-Z][a-zA-Z0-9_]# ]] || text=
+    text=$(command machine) 2>/dev/null && [[ $text == [a-zA-Z][a-zA-Z0-9_]# ]] ||
+      text=$(command arch) 2>/dev/null && [[ $text == [a-zA-Z][a-zA-Z0-9_]# ]] ||
+      text=
     state=_${(U)text}
     _p9k_cache_ephemeral_set "$state" "$text"
   fi


### PR DESCRIPTION
This uses the "machine" command instead of "arch" where available. This is preferable as it displays the actual architecture. For example:
- On a 64-bit Intel Mac, `arch` returns 'i386', while `machine` returns 'x86_64' or 'x86_64h'
- On an ARM Mac, `arch` returns 'arm64', while `machine` returns 'arm64e'
- On a PPC Mac, `arch` returns 'ppc', while `machine` returns the more specific variant (e.g. 'ppc7450')