### PR TITLE
Add AWS partitions support to EKS kubernetes cluster names

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4520,7 +4520,7 @@ prompt_kubecontext() {
           text=$cloud_cluster
         fi
       # arn:aws:eks:us-east-1:123456789012:cluster/cluster-01
-      elif [[ $cluster == (#b)arn:aws:eks:([[:alnum:]-]##):([[:digit:]]##):cluster/(?*) ]]; then
+      elif [[ $cluster == (#b)arn:aws[[:alnum:]-]#:eks:([[:alnum:]-]##):([[:digit:]]##):cluster/(?*) ]]; then
         cloud_name=eks
         cloud_zone=$match[1]
         cloud_account=$match[2]


### PR DESCRIPTION
The AWS ARN in govcloud and china looks different to the currently supported one:

https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-arns.html https://docs.amazonaws.cn/en_us/aws/latest/userguide/ARNs.html

This change introduces support for all possible AWS partitions.