### PR TITLE
Add manual MesloLGS NF font installation for Zed

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,19 @@ If you are using a different terminal, proceed with manual font installation. ðŸ
      ```
      After changing the config run `xrdb ~/.Xresources` to reload it. The new config is applied to
      all new terminals.
+   - **Zed**: Open `settings.json` file (type `CMD + ,` or open `~/.config/zed/settings.json`).
+     Add the following lines to your existing settings:
+     ```jsonc
+     {
+          // your existing settings
+
+          {
+              "terminal": {
+                  "font_family": "MesloLGS NF"
+              }
+          }
+     }
+     ```
    - Crostini (Linux on Chrome OS): Open
      chrome-untrusted://terminal/html/nassh_preferences_editor.html, set *Text font family* to
       `'MesloLGS NF'` (including the quotes) and *Custom CSS (inline text)* to the following:

--- a/font.md
+++ b/font.md
@@ -115,6 +115,19 @@ If you are using a different terminal, proceed with manual font installation. ðŸ
      ```
      After changing the config run `xrdb ~/.Xresources` to reload it. The new config is applied to
      all new terminals.
+   - **Zed**: Open `settings.json` file (type `CMD + ,` or open `~/.config/zed/settings.json`).
+     Add the following lines to your existing settings:
+     ```jsonc
+     {
+          // your existing settings
+
+          {
+              "terminal": {
+                  "font_family": "MesloLGS NF"
+              }
+          }
+     }
+     ```
    - Crostini (Linux on Chrome OS): Open
      chrome-untrusted://terminal/html/nassh_preferences_editor.html, set *Text font family* to
       `'MesloLGS NF'` (including the quotes) and *Custom CSS (inline text)* to the following:


### PR DESCRIPTION
Changes:

- Added instructions for manually installing MesloLGS NF font for terminal in the new [Zed code editor](https://zed.dev/)

<img width="1728" alt="CleanShot 2023-03-15 at 12 28 16@2x" src="https://user-images.githubusercontent.com/26031133/225421778-cfdb969a-8df1-4ce9-b52e-e9f7d66d97f8.png">