### PR TITLE
chore(Readme): fix oh-my-zsh git clone taget path for arbitrary `$ZSH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,13 +441,13 @@ make sure to disable the current theme in your plugin manager. See
 
 1. Clone the repository:
     ```zsh
-    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $ZSH_CUSTOM/themes/powerlevel10k
     ```
     Users in China can use the official mirror on gitee.com for faster download.<br>
     中国用户可以使用 gitee.com 上的官方镜像加速下载.
 
     ```zsh
-    git clone --depth=1 https://gitee.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+    git clone --depth=1 https://gitee.com/romkatv/powerlevel10k.git $ZSH_CUSTOM/themes/powerlevel10k
     ```
 2. Set `ZSH_THEME="powerlevel10k/powerlevel10k"` in `~/.zshrc`.
 


### PR DESCRIPTION
Some users might have their `$ZSH` defines in another location than `$HOME/.oh-my-zsh`. Hence, `$ZSH_CUSTOM` should use this location instead of `$HOME/.oh-my-zsh/custom`. `$ZSH_CUSTOM` will be set by `oh-my-zsh.sh` as `$ZSH/custom` when sourcing and should always be defined. 