### PR TITLE
nvm: implement POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW and default to false

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -1007,6 +1007,9 @@
   ##############[ nvm: node.js version from nvm (https://github.com/nvm-sh/nvm) ]###############
   # Nvm color.
   typeset -g POWERLEVEL9K_NVM_FOREGROUND=70
+  # If set to false, hide node version if it's the same as default:
+  # $(nvm version current) == $(nvm version default).
+  typeset -g POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide node version if it's equal to "system".
   typeset -g POWERLEVEL9K_NVM_SHOW_SYSTEM=true
   # Custom icon.

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -988,6 +988,9 @@
   ##############[ nvm: node.js version from nvm (https://github.com/nvm-sh/nvm) ]###############
   # Nvm color.
   typeset -g POWERLEVEL9K_NVM_FOREGROUND=2
+  # If set to false, hide node version if it's the same as default:
+  # $(nvm version current) == $(nvm version default).
+  typeset -g POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide node version if it's equal to "system".
   typeset -g POWERLEVEL9K_NVM_SHOW_SYSTEM=true
   # Custom icon.

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -984,6 +984,9 @@
   ##############[ nvm: node.js version from nvm (https://github.com/nvm-sh/nvm) ]###############
   # Nvm color.
   typeset -g POWERLEVEL9K_NVM_FOREGROUND=70
+  # If set to false, hide node version if it's the same as default:
+  # $(nvm version current) == $(nvm version default).
+  typeset -g POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide node version if it's equal to "system".
   typeset -g POWERLEVEL9K_NVM_SHOW_SYSTEM=true
   # Custom icon.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -1053,6 +1053,9 @@
   # Nvm color.
   typeset -g POWERLEVEL9K_NVM_FOREGROUND=0
   typeset -g POWERLEVEL9K_NVM_BACKGROUND=5
+  # If set to false, hide node version if it's the same as default:
+  # $(nvm version current) == $(nvm version default).
+  typeset -g POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide node version if it's equal to "system".
   typeset -g POWERLEVEL9K_NVM_SHOW_SYSTEM=true
   # Custom icon.

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -2567,7 +2567,10 @@ _p9k_nvm_ls_current() {
 prompt_nvm() {
   [[ -n $NVM_DIR ]] && _p9k_nvm_ls_current || return
   local current=$_p9k__ret
-  ! _p9k_nvm_ls_default || [[ $_p9k__ret != $current ]] || return
+  _p9k_nvm_ls_default
+  if (( !_POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW )); then
+    [[ $current == $_p9k__ret ]] && return
+  fi
   if (( !_POWERLEVEL9K_NVM_SHOW_SYSTEM )); then
     [[ $current == system ]] && return
   fi
@@ -7533,6 +7536,7 @@ _p9k_init_params() {
   _p9k_declare -b POWERLEVEL9K_NODENV_PROMPT_ALWAYS_SHOW 0
   _p9k_declare -a POWERLEVEL9K_NODENV_SOURCES -- shell local global
   _p9k_declare -b POWERLEVEL9K_NODENV_SHOW_SYSTEM 1
+  _p9k_declare -b POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW 0
   _p9k_declare -b POWERLEVEL9K_NVM_SHOW_SYSTEM 1
   _p9k_declare -b POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW 0
   _p9k_declare -a POWERLEVEL9K_RBENV_SOURCES -- shell local global


### PR DESCRIPTION
(This really should have been a part of #2295 but I just wasn't so sure if the implementation was correct at the time.)

`POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW` will, if set to false, hide the version if it's same as the default version (hide if `$(nvm version current) == $(nvm version default)`). This is the current default behavior so the default option is set to `false`.

The implementation of this looks a little different from the other `_PROMPT_ALWAYS_SHOW` implementations so maybe some double-checking might be necessary, but for me this works.

I think this should be merged since #2295 allows the prompt to be hidden if the version is set to the system version, and by default the version is _also_ hidden if it's the same as the default version. So you might run into a situation where the version is hidden but you're not sure if it's because you're using the system version or the default version (since you have no control over hiding/showing it if it's the same as the default version), and this PR addresses that.

Closes #1447