### PR TITLE
chezmoi: add chezmoi prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ enable as many segments as you like. It won't slow down your prompt or Zsh start
 | `azure` | [azure](https://docs.microsoft.com/en-us/cli/azure) account name |
 | `background_jobs` | presence of background jobs |
 | `battery` | internal battery state and charge level (yep, batteries *literally* included) |
+| `chezmoi` | [chezmoi](https://github.com/twpayne/chezmoi) shell |
 | `command_execution_time` | duration (wall time) of the last command |
 | `context` | user@hostname |
 | `cpu_arch` | CPU architecture |

--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -42,6 +42,7 @@
     status                  # exit code of the last command
     command_execution_time  # duration of the last command
     background_jobs         # presence of background jobs
+    chezmoi                 # chezmoi prompt (https://github.com/twpayne/chezmoi)
     direnv                  # direnv status (https://direnv.net/)
     asdf                    # asdf version manager (https://github.com/asdf-vm/asdf)
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)

--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -737,6 +737,12 @@
   # Custom icon.
   # typeset -g POWERLEVEL9K_XPLR_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
+  ##################[ chezmoi: chezmoi shell (https://github.com/twpayne/chezmoi) ]##################
+  # chezmoi shell color.
+  typeset -g POWERLEVEL9K_CHEZMOI_FOREGROUND=72
+  # Custom icon.
+  # typeset -g POWERLEVEL9K_CHEZMOI_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
   ###########################[ vim_shell: vim shell indicator (:sh) ]###########################
   # Vim shell indicator color.
   typeset -g POWERLEVEL9K_VIM_SHELL_FOREGROUND=34

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -735,6 +735,12 @@
   # Custom icon.
   # typeset -g POWERLEVEL9K_XPLR_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
+  ##################[ chezmoi: chezmoi shell (https://github.com/twpayne/chezmoi) ]##################
+  # chezmoi shell color.
+  typeset -g POWERLEVEL9K_CHEZMOI_FOREGROUND=72
+  # Custom icon.
+  # typeset -g POWERLEVEL9K_CHEZMOI_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
   ###########################[ vim_shell: vim shell indicator (:sh) ]###########################
   # Vim shell indicator color.
   typeset -g POWERLEVEL9K_VIM_SHELL_FOREGROUND=3

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -42,6 +42,7 @@
     status                  # exit code of the last command
     command_execution_time  # duration of the last command
     background_jobs         # presence of background jobs
+    chezmoi                 # chezmoi prompt (https://github.com/twpayne/chezmoi)
     direnv                  # direnv status (https://direnv.net/)
     asdf                    # asdf version manager (https://github.com/asdf-vm/asdf)
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -42,6 +42,7 @@
     status                  # exit code of the last command
     command_execution_time  # duration of the last command
     background_jobs         # presence of background jobs
+    chezmoi                 # chezmoi prompt (https://github.com/twpayne/chezmoi)
     direnv                  # direnv status (https://direnv.net/)
     asdf                    # asdf version manager (https://github.com/asdf-vm/asdf)
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -731,6 +731,12 @@
   # Custom icon.
   # typeset -g POWERLEVEL9K_XPLR_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
+  ##################[ chezmoi: chezmoi shell (https://github.com/twpayne/chezmoi) ]##################
+  # chezmoi shell color.
+  typeset -g POWERLEVEL9K_CHEZMOI_FOREGROUND=72
+  # Custom icon.
+  # typeset -g POWERLEVEL9K_CHEZMOI_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
   ###########################[ vim_shell: vim shell indicator (:sh) ]###########################
   # Vim shell indicator color.
   typeset -g POWERLEVEL9K_VIM_SHELL_FOREGROUND=34

--- a/config/p10k-pure.zsh
+++ b/config/p10k-pure.zsh
@@ -51,6 +51,7 @@
     newline                   # \n
     virtualenv                # python virtual environment
     prompt_char               # prompt symbol
+    chezmoi                   # chezmoi prompt (https://github.com/twpayne/chezmoi)
   )
 
   # Right prompt segments.

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -759,6 +759,13 @@
   # Custom icon.
   # typeset -g POWERLEVEL9K_XPLR_VISUAL_IDENTIFIER_EXPANSION='⭐'
 
+  ##################[ chezmoi: chezmoi shell (https://github.com/twpayne/chezmoi) ]##################
+  # chezmoi shell color.
+  typeset -g POWERLEVEL9K_CHEZMOI_FOREGROUND=0
+  typeset -g POWERLEVEL9K_CHEZMOI_BACKGROUND=6
+  # Custom icon.
+  # typeset -g POWERLEVEL9K_CHEZMOI_VISUAL_IDENTIFIER_EXPANSION='⭐'
+
   ###########################[ vim_shell: vim shell indicator (:sh) ]###########################
   # Vim shell indicator color.
   typeset -g POWERLEVEL9K_VIM_SHELL_FOREGROUND=0

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -45,6 +45,7 @@
     direnv                  # direnv status (https://direnv.net/)
     asdf                    # asdf version manager (https://github.com/asdf-vm/asdf)
     virtualenv              # python virtual environment (https://docs.python.org/3/library/venv.html)
+    chezmoi                 # chezmoi prompt (https://github.com/twpayne/chezmoi)
     anaconda                # conda environment (https://conda.io/)
     pyenv                   # python environment (https://github.com/pyenv/pyenv)
     goenv                   # go environment (https://github.com/syndbg/goenv)

--- a/internal/icons.zsh
+++ b/internal/icons.zsh
@@ -107,6 +107,7 @@ function _p9k_init_icons() {
         VCS_SVN_ICON                   'svn'$q
         RUST_ICON                      'R'
         PYTHON_ICON                    '\uE63C'$s             #  (doesn't always work)
+        CHEZMOI_ICON                   '\uf015'               # 
         SWIFT_ICON                     'Swift'
         GO_ICON                        'Go'
         GOLANG_ICON                    'Go'
@@ -243,6 +244,7 @@ function _p9k_init_icons() {
         VCS_SVN_ICON                   'svn'$q
         RUST_ICON                      '\uE6A8'               # 
         PYTHON_ICON                    '\uE63C'$s             # 
+        CHEZMOI_ICON                   '\uf015'               # 
         SWIFT_ICON                     'Swift'
         GO_ICON                        'Go'
         GOLANG_ICON                    'Go'
@@ -384,6 +386,7 @@ function _p9k_init_icons() {
         VCS_SVN_ICON                   'svn'$q
         RUST_ICON                      '\uE6A8'                                       # 
         PYTHON_ICON                    '\U1F40D'                                      # 🐍
+        CHEZMOI_ICON                    "${CODEPOINT_OF_AWESOME_HOME:+\\u$CODEPOINT_OF_AWESOME_HOME}"
         SWIFT_ICON                     '\uE655'$s                                     # 
         PUBLIC_IP_ICON                 "${CODEPOINT_OF_AWESOME_GLOBE:+\\u$CODEPOINT_OF_AWESOME_GLOBE$s}"
         LOCK_ICON                      "${CODEPOINT_OF_AWESOME_LOCK:+\\u$CODEPOINT_OF_AWESOME_LOCK}"
@@ -519,6 +522,7 @@ function _p9k_init_icons() {
         VCS_SVN_ICON                   '\uE72D'$q             # 
         RUST_ICON                      '\uE7A8'$q             # 
         PYTHON_ICON                    '\UE73C '              # 
+        CHEZMOI_ICON                   '\Uf015'               # 
         SWIFT_ICON                     '\uE755'               # 
         GO_ICON                        '\uE626'               # 
         GOLANG_ICON                    '\uE626'               # 
@@ -656,6 +660,7 @@ function _p9k_init_icons() {
         VCS_SVN_ICON                   '\uE72D'$q             # 
         RUST_ICON                      '\uE7A8'$q             # 
         PYTHON_ICON                    '\UE73C '              # 
+        CHEZMOI_ICON                   '\Uf015'               # 
         SWIFT_ICON                     '\uE755'               # 
         GO_ICON                        '\uE626'               # 
         GOLANG_ICON                    '\uE626'               # 

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4271,6 +4271,10 @@ _p9k_prompt_chezmoi_init() {
   typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$CHEZMOI'
 }
 
+function instant_prompt_chezmoi() {
+  _p9k_prompt_segment prompt_chezmoi "black" "white" CHEZMOI_ICON 0 '' 'chezmoi'
+}
+
 ################################################################
 # Virtualenv: current working virtualenv
 # More information on virtualenv (Python):

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4264,7 +4264,7 @@ instant_prompt_vi_mode() {
 # Segment to display chezmoi information.
 # More information: https://www.chezmoi.io/
 prompt_chezmoi() {
-  _p9k_prompt_segment "$0" "blue" "$_p9k_color1" '' 0 '' "chezmoi"
+  _p9k_prompt_segment "$0" "black" "white" 'CHEZMOI_ICON' 0 '' "chezmoi"
 }
 
 _p9k_prompt_chezmoi_init() {

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4261,6 +4261,17 @@ instant_prompt_vi_mode() {
 }
 
 ################################################################
+# Segment to display chezmoi information.
+# More information: https://www.chezmoi.io/
+prompt_chezmoi() {
+  _p9k_prompt_segment "$0" "blue" "$_p9k_color1" '' 0 '' "chezmoi"
+}
+
+_p9k_prompt_chezmoi_init() {
+  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$CHEZMOI'
+}
+
+################################################################
 # Virtualenv: current working virtualenv
 # More information on virtualenv (Python):
 # https://virtualenv.pypa.io/en/latest/


### PR DESCRIPTION
Hi,
I would like to add [chezmoi](https://github.com/twpayne/chezmoi) prompt. Do you think this something that could be integrated into p10k?

To give you some context, when I run `chezmoi cd`, chezmoi creates a shell and sets various environment variables. So the plan is to show the prompt  when we detect the `CHEZMOI` variable.

Before to finish my PR I would like to know what do you think about this idea.

Even if you reject this PR, I have technical question for you. I can't apply color to my prompt. I'm using `pure` theme, I tried to create `typeset -g POWERLEVEL9K_CHEZMOI_FOREGROUND=$grey` in `config/p10k-pure.zsh` without success.

<img width="324" alt="Screenshot 2023-05-18 at 12 09 39" src="https://github.com/romkatv/powerlevel10k/assets/60134194/cfab63ac-c873-407c-b859-a2e120e1209d">
