### PR TITLE
fix: adjusted to timewarrior new data dir path

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5086,6 +5086,9 @@ function _p9k_timewarrior_clear() {
 function prompt_timewarrior() {
   local -a stat
   local dir=${TIMEWARRIORDB:-~/.timewarrior}/data
+  if [[ ! -d $dir ]]; then
+    dir=${XDG_DATA_HOME:-$HOME/.local/share}/timewarrior/data
+  fi
   [[ $dir == $_p9k_timewarrior_dir ]] || _p9k_timewarrior_clear
   if [[ -n $_p9k_timewarrior_file_name ]]; then
     zstat -A stat +mtime -- $dir $_p9k_timewarrior_file_name 2>/dev/null || stat=()


### PR DESCRIPTION
Adjusted dir variable to the new path that Timewarrior is currently using, in the current p10k version Timewarrior integration was not working

> On Unix systems, XDG Base Directory specification is supported, if ~/.timewarrior directory doesn’t exist (old config directory is still supported and has precedence over XDG BD compliant locations).

This means data is stored in $XDG_DATA_HOME/timewarrior/data, which defaults to ~/.local/share/timewarrior/data if $XDG_DATA_HOME environment variable is not specified.