### PR TITLE
Fix font download error.

### DIFF
--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -518,6 +518,13 @@ function install_font() {
       local style
       for style in Regular Bold Italic 'Bold Italic'; do
         local file="MesloLGS NF ${style}.ttf"
+
+        print "$file ==Ready to download=="
+        if [[ -f ~"/Library/Fonts/$file" ]]; then
+          print "$file ==Already exist=="
+          continue
+        fi
+
         run_command "Downloading %B$file%b" \
           curl -fsSL -o ~/Library/Fonts/$file.tmp "$font_base_url/${file// /%20}"
         command mv -f -- ~/Library/Fonts/$file{.tmp,} || quit -c


### PR DESCRIPTION
Update content：Do not download again when I already have these fonts locally.

Error encountered while downloading the font：
Downloading MesloLGS NF Regular.ttf ... ERROR

Command: curl -fsSL -o /Users/weiwei/Library/Fonts/MesloLGS\ NF\ Regular.ttf.tmp https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Regular.ttf

curl: (35) LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to raw.githubusercontent.com:443