### PR TITLE
chore: `.tool-versions` as `asdf` anchor file

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -242,7 +242,7 @@
     .java-version
     .perl-version
     .php-version
-    .tool-version
+    .tool-versions
     .shorten_folder_marker
     .svn
     .terraform

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -233,7 +233,7 @@
     .java-version
     .perl-version
     .php-version
-    .tool-version
+    .tool-versions
     .shorten_folder_marker
     .svn
     .terraform

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -233,7 +233,7 @@
     .java-version
     .perl-version
     .php-version
-    .tool-version
+    .tool-versions
     .shorten_folder_marker
     .svn
     .terraform

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -242,7 +242,7 @@
     .java-version
     .perl-version
     .php-version
-    .tool-version
+    .tool-versions
     .shorten_folder_marker
     .svn
     .terraform


### PR DESCRIPTION
Prior to this change, `.tool-version` appeared in config templates, despite being correctly handled in `internal/p10k.zsh`.

Ref: <https://asdf-vm.com/manage/configuration.html#tool-versions>