### PR TITLE
Adjust pyenv content

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -992,6 +992,9 @@
   typeset -g POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide python version if it's equal to "system".
   typeset -g POWERLEVEL9K_PYENV_SHOW_SYSTEM=true
+  # Show pyenv only when the command you are typing matches one of these strings.
+  # Tip: You might want to enable POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW above.
+  # typeset -g POWERLEVEL9K_PYENV_SHOW_ON_COMMAND='py*|pip*|poetry|virtualenv'
 
   # Pyenv segment format. The following parameters are available within the expansion.
   #
@@ -1003,7 +1006,7 @@
   # 1. Display just "$P9K_CONTENT" if it's equal to "$P9K_PYENV_PYTHON_VERSION" or
   #    starts with "$P9K_PYENV_PYTHON_VERSION/".
   # 2. Otherwise display "$P9K_CONTENT $P9K_PYENV_PYTHON_VERSION".
-  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+ $P9K_PYENV_PYTHON_VERSION}'
+  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+$P9K_PYENV_PYTHON_VERSION}'
 
   # Custom icon.
   # typeset -g POWERLEVEL9K_PYENV_VISUAL_IDENTIFIER_EXPANSION='⭐'

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -970,6 +970,9 @@
   typeset -g POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide python version if it's equal to "system".
   typeset -g POWERLEVEL9K_PYENV_SHOW_SYSTEM=true
+  # Show pyenv only when the command you are typing matches one of these strings.
+  # Tip: You might want to enable POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW above.
+  # typeset -g POWERLEVEL9K_PYENV_SHOW_ON_COMMAND='py*|pip*|poetry|virtualenv'
 
   # Pyenv segment format. The following parameters are available within the expansion.
   #
@@ -981,7 +984,7 @@
   # 1. Display just "$P9K_CONTENT" if it's equal to "$P9K_PYENV_PYTHON_VERSION" or
   #    starts with "$P9K_PYENV_PYTHON_VERSION/".
   # 2. Otherwise display "$P9K_CONTENT $P9K_PYENV_PYTHON_VERSION".
-  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+ $P9K_PYENV_PYTHON_VERSION}'
+  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+$P9K_PYENV_PYTHON_VERSION}'
 
   # Custom icon.
   # typeset -g POWERLEVEL9K_PYENV_VISUAL_IDENTIFIER_EXPANSION='⭐'

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -966,6 +966,9 @@
   typeset -g POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide python version if it's equal to "system".
   typeset -g POWERLEVEL9K_PYENV_SHOW_SYSTEM=true
+  # Show pyenv only when the command you are typing matches one of these strings.
+  # Tip: You might want to enable POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW above.
+  # typeset -g POWERLEVEL9K_PYENV_SHOW_ON_COMMAND='py*|pip*|poetry|virtualenv'
 
   # Pyenv segment format. The following parameters are available within the expansion.
   #
@@ -977,7 +980,7 @@
   # 1. Display just "$P9K_CONTENT" if it's equal to "$P9K_PYENV_PYTHON_VERSION" or
   #    starts with "$P9K_PYENV_PYTHON_VERSION/".
   # 2. Otherwise display "$P9K_CONTENT $P9K_PYENV_PYTHON_VERSION".
-  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+ $P9K_PYENV_PYTHON_VERSION}'
+  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+$P9K_PYENV_PYTHON_VERSION}'
 
   # Custom icon.
   # typeset -g POWERLEVEL9K_PYENV_VISUAL_IDENTIFIER_EXPANSION='⭐'

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -1038,6 +1038,9 @@
   typeset -g POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW=false
   # If set to false, hide python version if it's equal to "system".
   typeset -g POWERLEVEL9K_PYENV_SHOW_SYSTEM=true
+  # Show pyenv only when the command you are typing matches one of these strings.
+  # Tip: You might want to enable POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW above.
+  # typeset -g POWERLEVEL9K_PYENV_SHOW_ON_COMMAND='py*|pip*|poetry|virtualenv'
 
   # Pyenv segment format. The following parameters are available within the expansion.
   #
@@ -1049,7 +1052,7 @@
   # 1. Display just "$P9K_CONTENT" if it's equal to "$P9K_PYENV_PYTHON_VERSION" or
   #    starts with "$P9K_PYENV_PYTHON_VERSION/".
   # 2. Otherwise display "$P9K_CONTENT $P9K_PYENV_PYTHON_VERSION".
-  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+ $P9K_PYENV_PYTHON_VERSION}'
+  typeset -g POWERLEVEL9K_PYENV_CONTENT_EXPANSION='${P9K_CONTENT}${${P9K_CONTENT:#$P9K_PYENV_PYTHON_VERSION(|/*)}:+$P9K_PYENV_PYTHON_VERSION}'
 
   # Custom icon.
   # typeset -g POWERLEVEL9K_PYENV_VISUAL_IDENTIFIER_EXPANSION='⭐'


### PR DESCRIPTION
1. Remove a spurious space in several themes.
2. Add example for POWERLEVEL9K_PYENV_SHOW_ON_COMMAND