### PR TITLE
Add remotes of some git server instances

### DIFF
--- a/internal/icons.zsh
+++ b/internal/icons.zsh
@@ -247,6 +247,15 @@ function _p9k_init_icons() {
         VCS_GIT_BITBUCKET_ICON         '\uF171 '              # 
         VCS_GIT_GITLAB_ICON            '\uF296 '              # 
         VCS_GIT_AZURE_ICON             '\u2601 '              # ☁
+        VCS_GIT_ARCH_ICON              '\uF303 '              # 
+        VCS_GIT_CODEBERG_ICON          '\uF330 '              # 
+        VCS_GIT_DEBIAN_ICON            '\uF306 '              # 
+        VCS_GIT_FREEBSD_ICON           '\UF30C '              # 
+        VCS_GIT_FREEDESKTOP_ICON       '\uF360 '              # 
+        VCS_GIT_GNOME_ICON             '\uF361 '              # 
+        VCS_GIT_GNU_ICON               '\uE779 '              # 
+        VCS_GIT_KDE_ICON               '\uF332 '              # 
+        VCS_GIT_LINUX_ICON             '\uF17C '              # 
         VCS_HG_ICON                    '\uF0C3 '              # 
         VCS_SVN_ICON                   'svn'$q
         RUST_ICON                      '\uE6A8'               # 
@@ -533,6 +542,15 @@ function _p9k_init_icons() {
         VCS_GIT_BITBUCKET_ICON         '\uE703 '              # 
         VCS_GIT_GITLAB_ICON            '\uF296 '              # 
         VCS_GIT_AZURE_ICON             '\uEBE8 '              # 
+        VCS_GIT_ARCH_ICON              '\uF303 '              # 
+        VCS_GIT_CODEBERG_ICON          '\uF330 '              # 
+        VCS_GIT_DEBIAN_ICON            '\uF306 '              # 
+        VCS_GIT_FREEBSD_ICON           '\UF30C '              # 
+        VCS_GIT_FREEDESKTOP_ICON       '\uF360 '              # 
+        VCS_GIT_GNOME_ICON             '\uF361 '              # 
+        VCS_GIT_GNU_ICON               '\uE779 '              # 
+        VCS_GIT_KDE_ICON               '\uF332 '              # 
+        VCS_GIT_LINUX_ICON             '\uF17C '              # 
         VCS_HG_ICON                    '\uF0C3 '              # 
         VCS_SVN_ICON                   '\uE72D'$q             # 
         RUST_ICON                      '\uE7A8'$q             # 
@@ -675,6 +693,15 @@ function _p9k_init_icons() {
         VCS_GIT_BITBUCKET_ICON         '\uE703 '              # 
         VCS_GIT_GITLAB_ICON            '\uF296 '              # 
         VCS_GIT_AZURE_ICON             '\uFD03 '              # ﴃ
+        VCS_GIT_ARCH_ICON              '\uF303 '              # 
+        VCS_GIT_CODEBERG_ICON          '\uF330 '              # 
+        VCS_GIT_DEBIAN_ICON            '\uF306 '              # 
+        VCS_GIT_FREEBSD_ICON           '\UF30C '              # 
+        VCS_GIT_FREEDESKTOP_ICON       '\uF360 '              # 
+        VCS_GIT_GNOME_ICON             '\uF361 '              # 
+        VCS_GIT_GNU_ICON               '\uE779 '              # 
+        VCS_GIT_KDE_ICON               '\uF332 '              # 
+        VCS_GIT_LINUX_ICON             '\uF17C '              # 
         VCS_HG_ICON                    '\uF0C3 '              # 
         VCS_SVN_ICON                   '\uE72D'$q             # 
         RUST_ICON                      '\uE7A8'$q             # 
@@ -814,6 +841,15 @@ function _p9k_init_icons() {
         VCS_GIT_BITBUCKET_ICON         ''
         VCS_GIT_GITLAB_ICON            ''
         VCS_GIT_AZURE_ICON             ''
+        VCS_GIT_ARCH_ICON              ''
+        VCS_GIT_CODEBERG_ICON          ''
+        VCS_GIT_DEBIAN_ICON            ''
+        VCS_GIT_FREEBSD_ICON           ''
+        VCS_GIT_FREEDESKTOP_ICON       ''
+        VCS_GIT_GNOME_ICON             ''
+        VCS_GIT_GNU_ICON               ''
+        VCS_GIT_KDE_ICON               ''
+        VCS_GIT_LINUX_ICON             ''
         VCS_HG_ICON                    ''
         VCS_SVN_ICON                   ''
         RUST_ICON                      'rust'
@@ -955,6 +991,15 @@ function _p9k_init_icons() {
         VCS_GIT_BITBUCKET_ICON         ''
         VCS_GIT_GITLAB_ICON            ''
         VCS_GIT_AZURE_ICON             ''
+        VCS_GIT_ARCH_ICON              ''
+        VCS_GIT_CODEBERG_ICON          ''
+        VCS_GIT_DEBIAN_ICON            ''
+        VCS_GIT_FREEBSD_ICON           ''
+        VCS_GIT_FREEDESKTOP_ICON       ''
+        VCS_GIT_GNOME_ICON             ''
+        VCS_GIT_GNU_ICON               ''
+        VCS_GIT_KDE_ICON               ''
+        VCS_GIT_LINUX_ICON             ''
         VCS_HG_ICON                    ''
         VCS_SVN_ICON                   ''
         RUST_ICON                      'R'

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -3723,7 +3723,27 @@ function +vi-vcs-detect-changes() {
     elif [[ "$remote" =~ "stash" ]] then
       vcs_visual_identifier='VCS_GIT_BITBUCKET_ICON'
     elif [[ "$remote" =~ "gitlab" ]] then
-      vcs_visual_identifier='VCS_GIT_GITLAB_ICON'
+      elif [[ "$remote" =~ "archlinux" ]] then
+        vcs_visual_identifier='VCS_GIT_ARCH_ICON'
+      if [[ "$remote" =~ "freedesktop" ]] then
+        vcs_visual_identifier='VCS_GIT_FREEDESKTOP_ICON'
+      elif [[ "$remote" =~ "gnome" ]] then
+        vcs_visual_identifier='VCS_GIT_GNOME_ICON'
+      else
+        vcs_visual_identifier='VCS_GITLAB_ICON'
+      fi
+    elif [[ "$remote" =~ "codeberg" ]] then
+      vcs_visual_identifier='VCS_GIT_CODEBERG_ICON'
+    elif [[ "$remote" =~ "debian" ]] then
+      vcs_visual_identifier='VCS_GIT_DEBIAN_ICON'
+    elif [[ "$remote" =~ "freebsd" ]] then
+      vcs_visual_identifier='VCS_GIT_FREEBSD_ICON'
+    elif [[ "$remote" =~ "gnu" ]] then
+      vcs_visual_identifier='VCS_GIT_GNU_ICON'
+    elif [[ "$remote" =~ "kde" ]] then
+      vcs_visual_identifier='VCS_GIT_KDE_ICON'
+    elif [[ "$remote" =~ "kernel" ]] then
+      vcs_visual_identifier='VCS_GIT_LINUX_ICON'
     else
       vcs_visual_identifier='VCS_GIT_ICON'
     fi
@@ -3864,7 +3884,16 @@ function _p9k_vcs_icon() {
     *github*)                          _p9k__ret=VCS_GIT_GITHUB_ICON;;
     *bitbucket*)                       _p9k__ret=VCS_GIT_BITBUCKET_ICON;;
     *stash*)                           _p9k__ret=VCS_GIT_BITBUCKET_ICON;;
+    *archlinux*)                       _p9k__ret=VCS_GIT_ARCH_ICON;;
+    *freedesktop*)                     _p9k__ret=VCS_GIT_FREEDESKTOP_ICON;;
+    *gnome*)                           _p9k__ret=VCS_GIT_GNOME_ICON;;
     *gitlab*)                          _p9k__ret=VCS_GIT_GITLAB_ICON;;
+    *codeberg*)                        _p9k__ret=VCS_GIT_CODEBERG_ICON;;
+    *debian*)                          _p9k__ret=VCS_GIT_DEBIAN_ICON;;
+    (#i)*freebsd*)                     _p9k__ret=VCS_GIT_FREEBSD_ICON;;
+    *gnu*)                             _p9k__ret=VCS_GIT_GNU_ICON;;
+    *kde*)                             _p9k__ret=VCS_GIT_KDE_ICON;;
+    *kernel*)                          _p9k__ret=VCS_GIT_LINUX_ICON;;
     # Azure DevOps: visualstudio.com is the old hostname, dev.azure.com is the new one.
     # https://learn.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate
     (|*@|*.)(visualstudio.com|dev.azure.com)(|:*|/*))


### PR DESCRIPTION
Currently only icons for big providers of git hosting service are available.

Organizations of open source software usually manage their own instances.

Adding the remote addresses of some of this organizations will let us to identify via a glyph icon the remote providing the source code.

For example some `gitlab` instances in the wild like the ones from GNOME, freedesktop.org, KDE organization can get a more personal touch.

-  **Arch Linux** (https://gitlab.archlinux.org): Hosting their tools, mirrors, etc. Merge requests and Issues will be open to users in the foreseeable future.
-  **freedesktop.org** (https://gitlab.freedesktop.org): Software focused on interoperability and shared technology for open-source graphical and desktop systems.
-  **GNOME** (https://gitlab.gnome.org): Software from GNOME project.
-  **Codeberg** (https://codeberg.org): Collaboration platform providing Git hosting and services for free and open source software, content and projects. .
-  **Debian** (https://salsa.debian.org) Repository of Debian.
-  **FreeBSD** (https://cgit.freebsd.org): FreeBSD project.
-  **GNU** (https://www.gnu.org): GNU packages.
-  **KDE** (https://invent.kde.org): Software from GNOME project.
-  **Linux** (https://kernel.org/): The Linux kernel projects.

The Debian and KDE instances didn't use `gitlab` subdomain making it to not even being recognized as `gitlab` instance getting the `git` icon.

**NOTE:** Some glyphs are from Nerd Fonts 3.1.0, you may need to update your font.

**ANOTHER NOTE:** In the FreeBSD section `(#i)` is used because FreeBSD uses uppercases on their git commands and if someone don't change it to lowercase it wouldn't get the FreeBSD icon.

**IMPORTANT NOTE:** The logo used for KDE organization is the logo from their KDE Plasma desktop environment because in NerdFont the KDE logo is not available, I can merge it to `font-logos` project to then submit it to NF but will not be available until NF next release.

![screenshot1700779456](https://github.com/romkatv/powerlevel10k/assets/53124818/9a8c0e7b-cd88-4a46-8998-9c1b3682d856)
