### PR TITLE
use "rm" instead of "unlink" to delete old config file

### DIFF
--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1950,7 +1950,7 @@ function generate_config() {
   command mkdir -p -- ${__p9k_cfg_path:h} || return
 
   if [[ -e $__p9k_cfg_path ]]; then
-    unlink $__p9k_cfg_path || return
+    rm $__p9k_cfg_path || return
   fi
   print -lr -- "$header" "$lines[@]" >$__p9k_cfg_path
 }


### PR DESCRIPTION
this actually let me run the `p10k configure` script on OpenBSD which aborts with `generate_config:250: command not found: unlink` otherwise.

tested on PopOS/Ubuntu but `rm` should also be available on any linux distribution?