### PR TITLE
instant prompt: fix DCS escape substitution to also work with tmux passthrough

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -6629,7 +6629,7 @@ function _p9k_clear_instant_prompt() {
       fi
       print -rn -- $terminfo[rc]${(%):-%b%k%f%s%u}$terminfo[ed]
       local unexpected=${${content//$'\e[?'<->'c'}//$'\e['<->' q'}
-      unexpected=${(S)unexpected//$'\eP'*[^$'\e']#($'\e\\')}
+      unexpected=${(S)unexpected//$'\eP'($'\e\\'|*[^$'\e']($'\e\\'))}
       unexpected=${(S)unexpected//$'\e'[^$'\a\e']#($'\a'|$'\e\\')}
       # Visual Studio Code prints this garbage.
       unexpected=${${unexpected//$'\033[1;32mShell integration activated\033[0m\n'}//$'\r'}


### PR DESCRIPTION
While using instant prompt, I was occasionally getting the notice that my zsh config was producing output, but the actual output was always blank. I tracked it down to some escape codes produced by a plugin (base16-shell in my case) that was wrapping the escape codes in the tmux passthrough DCS.

Essentially it looked like: `\ePtmux;\e\e]4;0;rbg:28/2c/34\e\e\\\e\\`. The important thing to note is that any escape character in the passed-through escape code must be itself escaped with an escape character. This includes the ending ST (`\e\\`) itself if present.

Your pattern to ignore DCS in output produced after the instant prompt was almost working, but it matched the internal ST as the “end” and left a stray one in the unexpected content. The fix is seemingly to just force the substitution to match the ST that isn’t itself escaped, which just means removing the “0 or more occurrences” modifier for non-escape-character from the pattern. The `*` already takes care of matching anything else but it now requires a non-escape followed by ST for the “end”. This fixes the issue I was seeing. For the rare case where an empty DCS appears (`\eP\e\\`), I just put that as an alternate match to the `*[^$'\e']($'\e\\')` part.

Thanks for an incredibly fast, feature rich toolkit for zsh prompts that I only recently discovered. Wished I found it years ago!