### PR TITLE
add foot font instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,15 @@ If you are using a different terminal, proceed with manual font installation. ðŸ
        normal:
          family: "MesloLGS NF"
      ```
+   - **foot**: Create or open `~/.config/foot/foot.ini` and add the following section
+     to it:
+     ```ini
+     font=MesloLGS NF
+     ```
+     or to specify a custom font size, e.g. 12,
+     ```ini
+     font=MesloLGS NF:size=12
+     ``
     - **kitty**: Create or open `~/.config/kitty/kitty.conf` and add the following line to it:
       ```text
       font_family MesloLGS NF


### PR DESCRIPTION
This adds instructions to the README for users of [foot](https://codeberg.org/dnkl/foot) to enable the MesloLGS Nerd Font as the default in their terminal.