### PR TITLE
fix: use correct sourcehut repository url

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -7454,7 +7454,7 @@ _p9k_init_params() {
       'gnu.org'                        VCS_GIT_GNU_ICON
       'kde.org'                        VCS_GIT_KDE_ICON
       'kernel.org'                     VCS_GIT_LINUX_ICON
-      'sourcehut.org'                  VCS_GIT_SOURCEHUT_ICON
+      'sr.ht'                          VCS_GIT_SOURCEHUT_ICON
     )
     typeset -ga _POWERLEVEL9K_VCS_GIT_REMOTE_ICONS
     for domain icon in "${domain2icon[@]}"; do


### PR DESCRIPTION
sourcehut.org is the website of the organization but sr.ht is the website were the repositories are hosted.

![image](https://github.com/romkatv/powerlevel10k/assets/53124818/83ddae74-240b-42c8-a373-8ae8e5259575)

Thanks for addressing https://github.com/romkatv/powerlevel10k/pull/2493#issuecomment-1832595890