### PR TITLE
ignore battery status "Unknown"

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -1407,7 +1407,7 @@ _p9k_prompt_battery_set_args() {
       (( $#bats )) || return
 
       local -i energy_now energy_full power_now
-      local -i is_full=1 is_calculating is_charching
+      local -i is_full=1 is_calculating is_charching only_unknown_found=1
       local dir
       for dir in $bats; do
         local -i pow=0 full=0
@@ -1423,6 +1423,8 @@ _p9k_prompt_battery_set_args() {
           (( energy_now += _p9k__ret ))
         fi
         _p9k_read_file $dir/status(N) && local bat_status=$_p9k__ret || continue
+        [[ $bat_status == Unknown                             ]] && continue
+        only_unknown_found=0
         [[ $bat_status != Full                                ]] && is_full=0
         [[ $bat_status == Charging                            ]] && is_charching=1
         [[ $bat_status == (Charging|Discharging) && $pow == 0 ]] && is_calculating=1
@@ -1433,7 +1435,7 @@ _p9k_prompt_battery_set_args() {
       bat_percent=$(( 100. * energy_now / energy_full + 0.5 ))
       (( bat_percent > 100 )) && bat_percent=100
 
-      if (( is_full || (bat_percent == 100 && is_charching) )); then
+      if (( is_full || (bat_percent == 100 && (is_charching || only_unknown_found) ) )); then
         state=CHARGED
       else
         if (( is_charching )); then


### PR DESCRIPTION
Hello,
on my laptop I had the problem that the battery status would be shown as discharging when it is full.
This happens because two batteries are found: `/sys/class/power_supply/BAT1`, which is the main battery, and `/sys/class/power_supply/hid-0018:04F3:2AF0.0002-battery`, which does not provide any meaningful information about the battery level.
![batteries](https://github.com/romkatv/powerlevel10k/assets/92742829/795551ff-5842-46b9-bef0-ef37201d5812)

If my battery is full, p10k would read BAT1/status first and set `is_full` to 1. In the second loop iteration it would read hid-0018:04F3:2AF0.0002-battery/status, which is always "Unknown" regardless of context. Therefore, the `is_full` variable would be set to 0 again.

My commit changes two things:
- If the status "Unknown" was read in the current loop iteration, the status variables will remain unchanged to avoid overwriting correct results retrieved before.
- If all found batteries have the status Unknown, use CHARGED if bat_percent is calculated to be 100, otherwise use DISCONNECTED. Currently this scenario will always lead to DISCONNECTED being used