### PR TITLE
Add kotlin version prompt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ You can enable as many segments as you like. It won't slow down your prompt or Z
 | `ip` | IP address and bandwidth usage for a specified network interface |
 | `java_version` | [java](https://www.java.com/) version |
 | `jenv` | java environment from [jenv](https://github.com/jenv/jenv) |
+| `kotlin_version` | [kotlin](https://kotlinlang.org/) version |
 | `kubecontext` | current [kubernetes](https://kubernetes.io/) context |
 | `laravel_version` | [laravel php framework](https://laravel.com/) version |
 | `load` | CPU load |

--- a/internal/icons.zsh
+++ b/internal/icons.zsh
@@ -124,6 +124,7 @@ function _p9k_init_icons() {
         PYTHON_ICON                    '\uE63C'$s             #  (doesn't always work)
         CHEZMOI_ICON                   '\uE12C'$s             # 
         SWIFT_ICON                     'Swift'
+        KOTLIN_ICON                    '\U1F17A'              # 🅺
         GO_ICON                        'Go'
         GOLANG_ICON                    'Go'
         PUBLIC_IP_ICON                 'IP'
@@ -278,6 +279,7 @@ function _p9k_init_icons() {
         PYTHON_ICON                    '\uE63C'$s             # 
         CHEZMOI_ICON                   '\uF015'$s             # 
         SWIFT_ICON                     'Swift'
+        KOTLIN_ICON                    '\U1F17A'              # 🅺
         GO_ICON                        'Go'
         GOLANG_ICON                    'Go'
         PUBLIC_IP_ICON                 'IP'
@@ -437,6 +439,7 @@ function _p9k_init_icons() {
         PYTHON_ICON                    '\U1F40D'                                      # 🐍
         CHEZMOI_ICON                    "${CODEPOINT_OF_AWESOME_HOME:+\\u$CODEPOINT_OF_AWESOME_HOME$s}"
         SWIFT_ICON                     '\uE655'$s                                     # 
+        KOTLIN_ICON                    '\U1F17A'                                      # 🅺
         PUBLIC_IP_ICON                 "${CODEPOINT_OF_AWESOME_GLOBE:+\\u$CODEPOINT_OF_AWESOME_GLOBE$s}"
         LOCK_ICON                      "${CODEPOINT_OF_AWESOME_LOCK:+\\u$CODEPOINT_OF_AWESOME_LOCK}"
         NORDVPN_ICON                   "${CODEPOINT_OF_AWESOME_LOCK:+\\u$CODEPOINT_OF_AWESOME_LOCK}"
@@ -595,6 +598,7 @@ function _p9k_init_icons() {
         PYTHON_ICON                    '\UE73C '              # 
         CHEZMOI_ICON                   '\uF015'$s             # 
         SWIFT_ICON                     '\uE755'               # 
+        KOTLIN_ICON                    '\U1F17A'              # 🅺
         GO_ICON                        '\uE626'               # 
         GOLANG_ICON                    '\uE626'               # 
         PUBLIC_IP_ICON                 '\UF0AC'$s             # 
@@ -750,6 +754,7 @@ function _p9k_init_icons() {
         PYTHON_ICON                    '\UE73C '              # 
         CHEZMOI_ICON                   '\uF015'$s             # 
         SWIFT_ICON                     '\uE755'               # 
+        KOTLIN_ICON                    '\U1F17A'              # 🅺
         GO_ICON                        '\uE626'               # 
         GOLANG_ICON                    '\uE626'               # 
         PUBLIC_IP_ICON                 '\UF0AC'$s             # 
@@ -902,6 +907,7 @@ function _p9k_init_icons() {
         PYTHON_ICON                    'py'
         CHEZMOI_ICON                   'chezmoi'
         SWIFT_ICON                     'swift'
+        KOTLIN_ICON                    'kotlin'
         GO_ICON                        'go'
         GOLANG_ICON                    'go'
         PUBLIC_IP_ICON                 'ip'
@@ -1056,6 +1062,7 @@ function _p9k_init_icons() {
         PYTHON_ICON                    'Py'
         CHEZMOI_ICON                   'Chez'
         SWIFT_ICON                     'Swift'
+        KOTLIN_ICON                    'Kotlin'
         GO_ICON                        'Go'
         GOLANG_ICON                    'Go'
         PUBLIC_IP_ICON                 'IP'

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4519,6 +4519,18 @@ _p9k_prompt_swift_version_init() {
 }
 
 ################################################################
+# Segment to display Kotlin version
+prompt_kotlin_version() {
+  _p9k_cached_cmd 0 '' kotlin -version || return
+  [[ $_p9k__ret == (#b)[^[:digit:]]#([[:digit:].]##)* ]] || return
+  _p9k_prompt_segment "$0" "magenta" "white" 'KOTLIN_ICON' 0 '' "${match[1]//\%/%%}"
+}
+
+_p9k_prompt_kotlin_version_init() {
+  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='$commands[kotlin]'
+}
+
+################################################################
 # dir_writable: Display information about the user's permission to write in the current directory
 prompt_dir_writable() {
   if [[ ! -w "$_p9k__cwd_a" ]]; then


### PR DESCRIPTION
New `kotlin_version` prompt option that shows system [kotlin](https://kotlinlang.org/) version (official language used for Android application Development)

Works identical to existing `swift_version` option.

![p10k-kotlin-prompt](https://github.com/romkatv/powerlevel10k/assets/1331002/ee80767b-ce70-4bed-a353-c95543bd414c)

To test simply install Kotlin: `brew install kotlin` / `sudo snap install --classic kotlin` / [etc](https://kotlinlang.org/docs/command-line.html)
