### PR TITLE
fixes taskwarrior init data for taskwarrior v3

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5234,7 +5234,10 @@ function _p9k_taskwarrior_check_data() {
 }
 
 function _p9k_taskwarrior_init_data() {
-  local -a stat files=($_p9k_taskwarrior_data_dir/{pending,completed}.data)
+  local -a stat files=(
+    $_p9k_taskwarrior_data_dir/{pending,completed}.data
+    $_p9k_taskwarrior_data_dir/taskchampion.sqlite3
+  )
   _p9k_taskwarrior_data_files=($^files(N))
   _p9k_taskwarrior_data_non_files=(${files:|_p9k_taskwarrior_data_files})
   if (( $#_p9k_taskwarrior_data_files )); then


### PR DESCRIPTION
Since [Taskwarrior 3.0](https://taskwarrior.org/docs/upgrade-3/) the tasks are now stored in `taskchampion.sqlite3`. This PR adds this file to the array of files to check, if a segment update is needed. The old files `{pending,completed}.data` are kept for backwards compatibility.