### PR TITLE
Fixes "bad floating point" problem with task-3.0.1

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5262,8 +5262,8 @@ function _p9k_taskwarrior_init_data() {
 
   if (( _p9k_taskwarrior_counters[PENDING] > _p9k_taskwarrior_counters[OVERDUE] )); then
     local -a ts
-    ts=($(command task +PENDING -OVERDUE list rc.verbose=nothing rc.color=0 rc._forcecolor=0 \
-      rc.report.list.labels= rc.report.list.columns=due.epoch </dev/null 2>/dev/null)) || ts=()
+    ts=$(command task +PENDING -OVERDUE list rc.verbose=nothing rc.color=0 rc._forcecolor=0 \
+      rc.report.list.labels= rc.report.list.columns=due.epoch </dev/null 2>/dev/null) || ts=()
     if (( $#ts )); then
       _p9k_taskwarrior_next_due=${${(on)ts}[1]}
       (( _p9k_taskwarrior_next_due > EPOCHSECONDS )) || _p9k_taskwarrior_next_due=$((EPOCHSECONDS+60))


### PR DESCRIPTION
After upgrading TaskWarrior to 3.0.1, I think... the comand means to
return some "Runnable" which resolves to a float, now returns the float
itself. So when we try to resolve the Runnable, ZSH throws an exception,
and p10k cannot parse the float from that. This just changes the
assumption that we get a float back.

p.s: Please when reviewing, ask youself "How does this affect P10K at
large?" I don't have this purview, but this change sure fixes my
problem.

Fixes #2648
