### PR TITLE
Allow setting a cache file name suffix, e.g. "-${TERM}"

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -6161,7 +6161,7 @@ _p9k_dump_instant_prompt() {
   local user=${(%):-%n}
   local root_dir=${__p9k_dump_file:h}
   local prompt_dir=${root_dir}/p10k-$user
-  local root_file=$root_dir/p10k-instant-prompt-$user.zsh
+  local root_file=$root_dir/p10k-instant-prompt-$user${_P10K_CACHE_SUFFIX}.zsh
   local prompt_file=$prompt_dir/prompt-${#_p9k__cwd}
   [[ -d $prompt_dir ]] || mkdir -p $prompt_dir || return
   [[ -w $root_dir && -w $prompt_dir ]] || return
@@ -6461,7 +6461,7 @@ _p9k_dump_instant_prompt() {
   else
     local tmpdir=/tmp
   fi
-  typeset -g __p9k_instant_prompt_output=$tmpdir/p10k-instant-prompt-output-${(%):-%n}-$$
+  typeset -g __p9k_instant_prompt_output=$tmpdir/p10k-instant-prompt-output-${(%):-%n}${_P10K_CACHE_SUFFIX}-$$
   { : > $__p9k_instant_prompt_output } || return
   print -rn -- "${out}${esc}?2004h" || return
   if (( $+commands[stty] )); then
@@ -6476,7 +6476,7 @@ _p9k_dump_instant_prompt() {
     typeset -g _z4h_saved_screen
     -z4h-save-screen
   fi
-  typeset -g __p9k_instant_prompt_dump_file=${XDG_CACHE_HOME:-~/.cache}/p10k-dump-${(%):-%n}.zsh
+  typeset -g __p9k_instant_prompt_dump_file=${XDG_CACHE_HOME:-~/.cache}/p10k-dump-${(%):-%n}${_P10K_CACHE_SUFFIX}.zsh
   if builtin source $__p9k_instant_prompt_dump_file 2>/dev/null && (( $+functions[_p9k_preinit] )); then
     _p9k_preinit
   fi

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1981,8 +1981,8 @@ function change_zshrc() {
       >>$tmp print -r -- "# Enable Powerlevel10k instant prompt. Should stay close to the top of ${(%)__p9k_zshrc_u}.
 # Initialization code that may require console input (password prompts, [y/n]
 # confirmations, etc.) must go above this block; everything else may go below.
-if [[ -r \"\${XDG_CACHE_HOME:-\$HOME/.cache}/p10k-instant-prompt-\${(%):-%n}.zsh\" ]]; then
-  source \"\${XDG_CACHE_HOME:-\$HOME/.cache}/p10k-instant-prompt-\${(%):-%n}.zsh\"
+if [[ -r \"\${XDG_CACHE_HOME:-\$HOME/.cache}/p10k-instant-prompt-\${(%):-%n}\${_P10K_CACHE_SUFFIX}.zsh\" ]]; then
+  source \"\${XDG_CACHE_HOME:-\$HOME/.cache}/p10k-instant-prompt-\${(%):-%n}\${_P10K_CACHE_SUFFIX}.zsh\"
 fi" || return
     fi
     if [[ -n $zshrc_content ]]; then
@@ -2036,7 +2036,7 @@ function check_zshrc_integration() {
   if [[ -n ${(@M)lines:#(#b)[^#]#([^[:IDENT:]]|)source[[:space:]]##(|--[[:space:]]##)($f1|$f2|$f3|$f4|$g1|$h0|$h1|$h2|$h3|$h4|$h5|$h6|$h7|$h8|$h9|$h10|$h11)(|[[:space:]]*|'#'*)} ]]; then
     zshrc_has_cfg=1
   fi
-  local pre='${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh'
+  local pre='${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}${_P10K_CACHE_SUFFIX}.zsh'
   if [[ -n ${(@M)lines:#(#b)[^#]#([^[:IDENT:]]|)source[[:space:]]##($pre|\"$pre\")(|[[:space:]]*|'#'*)} ]]; then
     zshrc_has_instant_prompt=1
   fi

--- a/powerlevel10k.zsh-theme
+++ b/powerlevel10k.zsh-theme
@@ -53,7 +53,7 @@ function _p9k_init_locale() {
     (( $+functions[_p9k_setup] )) && _p9k_setup
     return 0
   fi
-  typeset -gr __p9k_dump_file=${XDG_CACHE_HOME:-~/.cache}/p10k-dump-${(%):-%n}.zsh
+  typeset -gr __p9k_dump_file=${XDG_CACHE_HOME:-~/.cache}/p10k-dump-${(%):-%n}${_P10K_CACHE_SUFFIX}.zsh
   if [[ $__p9k_dump_file != $__p9k_instant_prompt_dump_file ]] && (( ! $+functions[_p9k_preinit] )) && source $__p9k_dump_file 2>/dev/null && (( $+functions[_p9k_preinit] )); then
     _p9k_preinit
   fi


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
When mixing tmux (TERM=tmux-256color) and native terminal windows/tabs
(e.g. TERM=xterm-kitty), since they share the same instant prompt cache
files, the cache files are invalidated every time I start a new Zsh in a
different $TERM [1].

People who have this issue can set _P10K_CACHE_SUFFIX="-${TERM}" to work
around it.

[1] https://github.com/romkatv/powerlevel10k/commit/e2db8607456eb04186b84fc6edaaf567350e3dc0

<!-- === GH HISTORY FENCE === -->

---

I'm been using this myself for a while. It seems the only downside is
that people will need to delete the old no-$TERM cache files themselves.

Closes #2533
