### PR TITLE
Set P9K_SSH correctly when running in WSL

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -8473,13 +8473,13 @@ _p9k_init_ssh() {
   typeset -gix P9K_SSH=0
   typeset -gx _P9K_SSH_TTY=$TTY
   if [[ -n $SSH_CLIENT || -n $SSH_TTY || -n $SSH_CONNECTION ]]; then
-    p9k_ssh=1
+    P9K_SSH=1
     return 0
   elif [[ \
     $(grep -i Microsoft /proc/version) && \
     $(cmd.exe /c 'echo %SSH_CLIENT%' 2>/dev/null | sed $'s/\r//' | grep ' 22$') \
   ]]; then
-    p9k_ssh=1
+    P9K_SSH=1
     return 0
   fi
 


### PR DESCRIPTION
Solve  #2709 by checking if system is running in WSL and in that case if it is running under an SSH session