### PR TITLE
Add battery prompt for Wndows

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -1332,6 +1332,7 @@ _p9k_prompt_fvm_init() {
 }
 
 ################################################################
+# Segment that displays the battery status in levels and colors
 prompt_battery() {
   [[ $_p9k_os == (Linux|Android) ]] && _p9k_prompt_battery_set_args
   (( $#_p9k__battery_args )) && _p9k_prompt_segment "${_p9k__battery_args[@]}"


### PR DESCRIPTION
Thanks for your contribution and effort on p10k!
I use zsh and p10k based on **GitBash** in **Windows,** and I find that Battery Prompt is invalid for Windows.
It seems that there does not have a `case` for Windows to call `_p9k_prompt_battery_set_args()`. So, I add one for Windows, which uses `wimc` command to get battery info in Windows. Beside, I add a logic of checking the availability of `wimc` in current Windows system in `_p9k_prompt_battery_init()` .
I realize the Battery Prompt may not be seen as necessary on Windows, but I would like to propose that improving it could make a positive impact on the feature's completeness.
Hope you can consider merging. 