### PR TITLE
Support kitty's inclusion of cmdline in <OSC>133;C

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5812,7 +5812,7 @@ _p9k_preexec2() {
   typeset -g _p9k__preexec_cmd=$2
   _p9k__timer_start=EPOCHREALTIME
   P9K_TTY=old
-  (( ! $+_p9k__iterm_cmd )) || _p9k_iterm2_preexec
+  (( ! $+_p9k__iterm_cmd )) || _p9k_iterm2_preexec $_p9k__preexec_cmd
 }
 
 function _p9k_prompt_net_iface_init() {
@@ -8877,7 +8877,7 @@ function _p9k_iterm2_precmd() {
 }
 
 function _p9k_iterm2_preexec() {
-  [[ -t 1 ]] && builtin print -n '\e]133;C;\a'
+  [[ -t 1 ]] && builtin print -n -f '\e]133;C;cmdline=%q\a' $1
   typeset -gi _p9k__iterm_cmd=2
 }
 


### PR DESCRIPTION
As per kitty's shell-integration docs about the relevant change ~3months ago:

> kitty also optionally supports sending the cmdline going to be executed with ``<OSC>133;C`` as::
> ```
> <OSC>133;C;cmdline=cmdline encoded by %q<ST>
> or
> <OSC>133;C;cmdline_url=cmdline as UTF-8 URL %-escaped text<ST>
> ```
> Here, encoded by %q means the encoding produced by the %q format to printf in bash and similar shells.

[Original commit](https://github.com/kovidgoyal/kitty/commit/0d68a21be55fa14bd8a255f1bbab0c858fed61dc#diff-ae66d186516cb46812d8d78b69e235ab943b6c9b179094fba598766533ab04d2)
[Most recent revision](https://github.com/kovidgoyal/kitty/commit/219e53826b1764f977dd9fe60aea903f79ed66c1#diff-ae66d186516cb46812d8d78b69e235ab943b6c9b179094fba598766533ab04d2)

### Rationale

I was trying to enable behavior inside the kitty terminal such that I could automatically change its configuration depending on which program is running. Specifically, I wanted to enable font ligatures in kitty only in the window that neovim is running on when it is invoked, and disable ligatures on exit back to the prompt.

Fortunately, kitty already has a [watcher API](https://sw.kovidgoyal.net/kitty/launch/#watching-launched-windows) to program around certain events with a python script, one of the events being `on_cmd_startstop`. The script was fine except for the important part of matching the detected cmdline. After a bunch of bisecting my rc files, what I think is happening is that even though the cmdline is getting passed over by kitty's zsh integrations, p10k isn't handling it so nothing reaches my script. Disabling p10k successfully passes the cmdline over through the API.

---

Please let me know if any other changes are necessary and/or if what I introduced breaks anything else. I have limited knowledge of the codebase and just tried to make the smallest local change required to support kitty's extended spec.