### PR TITLE
docs: Add instructions for setting MesloLGS NF font in Deepin Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,14 @@ If you are using a different terminal, proceed with manual font installation. ðŸ
          font-style: italic;
      }
      ```
+   - **Deepin Terminal**: Open `~/.config/deepin/deepin-terminal/config.conf` and set `basic.interface.font` to `"MesloLGS NF"`.
+     ```ini
+     [basic.interface.font]
+        value="MesloLGS NF"
+
+      [basic.interface.font_size]
+        value=10
+     ```
      **_CAVEAT_**: If you open the normal terminal preferences these settings will be overwritten.
 1. Run `p10k configure` to generate a new `~/.p10k.zsh`. The old config may work
    incorrectly with the new font.


### PR DESCRIPTION
### Description of Changes:

**Purpose:**  
Added font configuration for correct display of the **Powerlevel10k** Zsh theme in Deepin Terminal. The **MesloLGS NF** font is required for proper rendering of symbols and icons used by Powerlevel10k.

### Changes:
- Updated instructions for setting the font in Deepin Terminal.
- In the configuration file `~/.config/deepin/deepin-terminal/config.conf`, it's recommended to add or modify the following font settings:

  ```ini
  [basic.interface.font]
  value="MesloLGS NF"

  [basic.interface.font_size]
  value=10

