### PR TITLE
Add AlmaLinux icon

### DIFF
--- a/internal/icons.zsh
+++ b/internal/icons.zsh
@@ -74,6 +74,7 @@ function _p9k_init_icons() {
         LINUX_AMZN_ICON                '\uE271'$s             # 
         LINUX_ENDEAVOUROS_ICON         '\uE271'$s             # 
         LINUX_ROCKY_ICON               '\uE271'$s             # 
+        LINUX_ALMALINUX_ICON           '\uE271'$s             # 
         LINUX_GUIX_ICON                '\uE271'$s             # 
         LINUX_NEON_ICON                '\uE271'$s             # 
         SUNOS_ICON                     '\U1F31E'$q            # 🌞
@@ -232,6 +233,7 @@ function _p9k_init_icons() {
         LINUX_AMZN_ICON                '\uF17C'$s             # 
         LINUX_ENDEAVOUROS_ICON         '\uF17C'$s             # 
         LINUX_ROCKY_ICON               '\uF17C'$s             # 
+        LINUX_ALMALINUX_ICON           '\uF17C'$s             # 
         LINUX_GUIX_ICON                '\uF17C'$s             # 
         LINUX_NEON_ICON                '\uF17C'$s             # 
         SUNOS_ICON                     '\uF185 '              # 
@@ -391,6 +393,7 @@ function _p9k_init_icons() {
         LINUX_AMZN_ICON                "${CODEPOINT_OF_AWESOME_LINUX:+\\u$CODEPOINT_OF_AWESOME_LINUX$s}"
         LINUX_ENDEAVOUROS_ICON         "${CODEPOINT_OF_AWESOME_LINUX:+\\u$CODEPOINT_OF_AWESOME_LINUX$s}"
         LINUX_ROCKY_ICON               "${CODEPOINT_OF_AWESOME_LINUX:+\\u$CODEPOINT_OF_AWESOME_LINUX$s}"
+        LINUX_ALMALINUX_ICON           "${CODEPOINT_OF_AWESOME_LINUX:+\\u$CODEPOINT_OF_AWESOME_LINUX$s}"
         LINUX_GUIX_ICON                "${CODEPOINT_OF_AWESOME_LINUX:+\\u$CODEPOINT_OF_AWESOME_LINUX$s}"
         LINUX_NEON_ICON                "${CODEPOINT_OF_AWESOME_LINUX:+\\u$CODEPOINT_OF_AWESOME_LINUX$s}"
         SUNOS_ICON                     "${CODEPOINT_OF_AWESOME_SUN_O:+\\u$CODEPOINT_OF_AWESOME_SUN_O }"
@@ -543,6 +546,7 @@ function _p9k_init_icons() {
         LINUX_AMZN_ICON                '\uF270'$s             # 
         LINUX_ENDEAVOUROS_ICON         '\UF322'$s             # 
         LINUX_ROCKY_ICON               '\UF32B'$s             # 
+        LINUX_ALMALINUX_ICON           '\UF31D'$s             # 
         LINUX_GUIX_ICON                '\UF325'$s             # 
         LINUX_NEON_ICON                '\uF17C'               # 
         LINUX_ICON                     '\uF17C'               # 
@@ -703,6 +707,7 @@ function _p9k_init_icons() {
         LINUX_AMZN_ICON                '\uF270'$s             # 
         LINUX_ENDEAVOUROS_ICON         '\uF17C'               # 
         LINUX_ROCKY_ICON               '\uF17C'               # 
+        LINUX_ALMALINUX_ICON           '\uF17C'               # 
         LINUX_GUIX_ICON                '\uF325'$s             # 
         LINUX_NEON_ICON                '\uF17C'               # 
         LINUX_ICON                     '\uF17C'               # 
@@ -856,6 +861,7 @@ function _p9k_init_icons() {
         LINUX_AMZN_ICON                'amzn'
         LINUX_ENDEAVOUROS_ICON         'edvos'
         LINUX_ROCKY_ICON               'rocky'
+        LINUX_ALMALINUX_ICON           'almalinux'
         LINUX_GUIX_ICON                'guix'
         LINUX_NEON_ICON                'neon'
         SUNOS_ICON                     'sunos'
@@ -1010,6 +1016,7 @@ function _p9k_init_icons() {
         LINUX_AMZN_ICON                'Amzn'
         LINUX_ENDEAVOUROS_ICON         'Edv'
         LINUX_ROCKY_ICON               'Roc'
+        LINUX_ALMALINUX_ICON           'Alma'
         LINUX_GUIX_ICON                'Guix'
         LINUX_NEON_ICON                'Neon'
         SUNOS_ICON                     'Sun'

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -8661,6 +8661,7 @@ function _p9k_init_cacheable() {
           amzn)                    _p9k_set_os Linux LINUX_AMZN_ICON;;
           endeavouros)             _p9k_set_os Linux LINUX_ENDEAVOUROS_ICON;;
           rocky)                   _p9k_set_os Linux LINUX_ROCKY_ICON;;
+          almalinux)               _p9k_set_os Linux LINUX_ALMALINUX_ICON;;
           guix)                    _p9k_set_os Linux LINUX_GUIX_ICON;;
           neon)                    _p9k_set_os Linux LINUX_NEON_ICON;;
           *)                       _p9k_set_os Linux LINUX_ICON;;

--- a/internal/wizard.zsh
+++ b/internal/wizard.zsh
@@ -1164,6 +1164,7 @@ function os_icon_name() {
           amzn)                    echo LINUX_AMZN_ICON;;
           endeavouros)             echo LINUX_ENDEAVOUROS_ICON;;
           rocky)                   echo LINUX_ROCKY_ICON;;
+          almalinux)               echo LINUX_ALMALINUX_ICON;;
           guix)                    echo LINUX_GUIX_ICON;;
           neon)                    echo LINUX_NEON_ICON;;
           *)                       echo LINUX_ICON;;


### PR DESCRIPTION
Add icon for [AlmaLinux](https://almalinux.org). Hex code #f31d in nerd fonts.