### PR TITLE
ssh: optimize detection

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -8479,7 +8479,8 @@ _p9k_init_ssh() {
 
   # When changing user on a remote system, the $SSH_CONNECTION environment variable can be lost.
   # Attempt detection via `who`.
-  (( $+commands[who] )) || return
+  [[ -z "$(command -v who)" ]] && return
+  #(( $+commands[who] )) || return
 
   local ipv6='(([0-9a-fA-F]+:)|:){2,}[0-9a-fA-F]+'  # Simplified, only checks partial pattern.
   local ipv4='([0-9]{1,3}\.){3}[0-9]+'              # Simplified, allows invalid ranges.


### PR DESCRIPTION
p10k's ssh detection is pretty thorough, but also pretty heavy, especially when the primary use case is local. on my m1 macbook, `(( $+commands[who] )) && return` costs 7 milliseconds.

this PR changes `$+commands[who]` to `command -v who`, which runs almost instantaneously in comparison.

the next biggest cost is in the regex match at the end of the function. it feels like ssh detection should be an optional thing. the best way i've found to bypass it is to set `P9K_SSH` and faking out `_P9K_TTY`, and forcing detection on `SSH_CLIENT` or `SSH_CONNECTION` alone, which i'm fine with.