### PR TITLE
support cpu_arch on Linux

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -5751,6 +5751,8 @@ prompt_cpu_arch() {
   if _p9k_cache_ephemeral_get $0; then
     state=$_p9k__cache_val[1]
     text=$_p9k__cache_val[2]
+  elif [[ $_p9k_os == (Linux|Android) ]]; then
+    text=$(</proc/sys/kernel/arch)
   else
     local cmd
     for cmd in machine arch; do


### PR DESCRIPTION
Linux does not have `arch` or `machine`, so we read from /proc instead.

Needs testing before it's committed as-is.

- [ ] Linux
- [ ] ~~WSL2~~ File does not exist. Looking for alternative.
- [ ] Android?

lmk if this isn't best practice for internal/ code. Thanks.