### PR TITLE
Let mise-configured ancestors be anchors

### DIFF
--- a/config/p10k-classic.zsh
+++ b/config/p10k-classic.zsh
@@ -244,6 +244,7 @@
     .perl-version
     .php-version
     .tool-versions
+    .mise.toml
     .shorten_folder_marker
     .svn
     .terraform

--- a/config/p10k-lean-8colors.zsh
+++ b/config/p10k-lean-8colors.zsh
@@ -235,6 +235,7 @@
     .perl-version
     .php-version
     .tool-versions
+    .mise.toml
     .shorten_folder_marker
     .svn
     .terraform

--- a/config/p10k-lean.zsh
+++ b/config/p10k-lean.zsh
@@ -235,6 +235,7 @@
     .perl-version
     .php-version
     .tool-versions
+    .mise.toml
     .shorten_folder_marker
     .svn
     .terraform

--- a/config/p10k-rainbow.zsh
+++ b/config/p10k-rainbow.zsh
@@ -244,6 +244,7 @@
     .perl-version
     .php-version
     .tool-versions
+    .mise.toml
     .shorten_folder_marker
     .svn
     .terraform


### PR DESCRIPTION
Hi @romkatv, thank you enormously for your invaluable contributions.
It's laudable that you're still offering continuous support for help requests, even "in spite" of your notice at the top of the README.

--

This simple PR lets powerlevel10k interpret directories that are configured with `mise` [1] be recognised as anchors.

It looks like there's quite a few alternate file names that `mise` would recognise [2], but the one that's created by default when you ask it to override your global/ancestral tool with a local one is `.mise.toml`, so I went with using this one only.

--

I'll see what I can do about answering https://github.com/romkatv/powerlevel10k/issues/2212 as well.

[1] https://github.com/jdx/mise
[2] https://mise.jdx.dev/configuration.html