### PR TITLE
docs(readme): remove mention of archlinux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,11 +536,6 @@ echo 'source /usr/share/zsh-theme-powerlevel10k/powerlevel10k.zsh-theme' >>~/.zs
 [zsh-theme-powerlevel10k-git](https://aur.archlinux.org/packages/zsh-theme-powerlevel10k-git/)
 referenced above is the official Powerlevel10k package.
 
-There is also [zsh-theme-powerlevel10k](
-  https://www.archlinux.org/packages/extra/x86_64/zsh-theme-powerlevel10k/) package.
-Historically, [it has been breaking often and for extended periods of time](
-  https://github.com/romkatv/powerlevel10k/pull/786). **Do not use it.**
-
 ### Alpine Linux
 
 ```zsh


### PR DESCRIPTION
powerlevel10k package doesn't exist on the arch repo now.