### PR TITLE
fix(prompt): add support for AWS_SSO_PROFILE in AWS segment initializ…

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -1206,7 +1206,7 @@ prompt_aws() {
 }
 
 _p9k_prompt_aws_init() {
-  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='${AWS_VAULT:-${AWSUME_PROFILE:-${AWS_PROFILE:-$AWS_DEFAULT_PROFILE}}}'
+  typeset -g "_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]"='${AWS_SSO_PROFILE:-${AWS_VAULT:-${AWSUME_PROFILE:-${AWS_PROFILE:-$AWS_DEFAULT_PROFILE}}}}'
 }
 
 ################################################################


### PR DESCRIPTION
The prompt's AWS segment was not displaying correctly when using the `AWS_SSO_PROFILE` environment variable. This issue occurred because the `_p9k_prompt_aws_init` function, responsible for determining whether the AWS segment should be displayed, did not account for `AWS_SSO_PROFILE`. Instead, it only considered other AWS-related environment variables.

As a result, users relying on AWS SSO for authentication could not see the AWS segment in their prompt, even though `AWS_SSO_PROFILE` was correctly set.

This change ensures compatibility with AWS SSO, improving the functionality of the AWS segment for users leveraging `AWS_SSO_PROFILE`. It does not alter behavior for users relying on other AWS environment variables, maintaining backward compatibility.