### PR TITLE
Fix word splitting issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,13 +455,13 @@ make sure to disable the current theme in your plugin manager. See
 
 1. Clone the repository:
     ```zsh
-    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"
     ```
     Users in China can use the official mirror on gitee.com for faster download.<br>
     中国用户可以使用 gitee.com 上的官方镜像加速下载.
 
     ```zsh
-    git clone --depth=1 https://gitee.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+    git clone --depth=1 https://gitee.com/romkatv/powerlevel10k.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"
     ```
 2. Open `~/.zshrc`, find the line that sets `ZSH_THEME`, and change its value to `"powerlevel10k/powerlevel10k"`.
 
@@ -857,7 +857,7 @@ The command to update Powerlevel10k depends on how it was installed.
 | Installation                  | Update command                                              |
 |-------------------------------|-------------------------------------------------------------|
 | [Manual](#manual)             | `git -C ~/powerlevel10k pull`                               |
-| [Oh My Zsh](#oh-my-zsh)       | `git -C ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k pull` |
+| [Oh My Zsh](#oh-my-zsh)       | `git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" pull` |
 | [Prezto](#prezto)             | `zprezto-update`                                            |
 | [Zim](#zim)                   | `zimfw update`                                              |
 | [Antigen](#antigen)           | `antigen update`                                            |
@@ -911,7 +911,7 @@ The command to update Powerlevel10k depends on how it was installed.
    | Installation                  | Uninstall command                                                |
    |-------------------------------|------------------------------------------------------------------|
    | [Manual](#manual)             | `rm -rf ~/powerlevel10k`                                         |
-   | [Oh My Zsh](#oh-my-zsh)       | `rm -rf -- ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k` |
+   | [Oh My Zsh](#oh-my-zsh)       | `rm -rf -- "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"` |
    | [Prezto](#prezto)             | n/a                                                              |
    | [Zim](#zim)                   | `zimfw uninstall`                                                |
    | [Antigen](#antigen)           | `antigen purge romkatv/powerlevel10k`                            |
@@ -1003,7 +1003,7 @@ Powerlevel10k does not affect:
 1. Run this command:
 ```zsh
 # Add powerlevel10k to the list of Oh My Zsh themes.
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $ZSH_CUSTOM/themes/powerlevel10k
+git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"
 # Replace ZSH_THEME="powerlevel9k/powerlevel9k" with ZSH_THEME="powerlevel10k/powerlevel10k".
 sed -i.bak 's/powerlevel9k/powerlevel10k/g' ~/.zshrc
 # Restart Zsh.
@@ -1574,7 +1574,7 @@ When opening a terminal, or starting zsh manually, you may encounter this error 
    - If `typeset -p P9K_VERSION` fails with the error `typeset: no such variable: P9K_VERSION`, run
      the following command:
      ```zsh
-     git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+     git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"
      ```
 2. Restart Zsh with `exec zsh`.
 


### PR DESCRIPTION
Hello!

I love powerlevel10k and I use it every day so I wanted to give back.

I took various commands from the readme and placed them into a shell script (bash), then ran shellcheck on the script and fixed the errors related to word-splitting.

I did this because in zsh, if you do `setopt shwordsplit` as per [ZSH FAQ Chapter 3.1](https://zsh.sourceforge.io/FAQ/zshfaq03.html), you get the same behavior as bourne shell derivatives.

Given that zsh does support word-splitting the same way as bash when the above is set in the user's environment, I wanted to ensure that, regardless of whether someone sets `shwordsplit` or not, there is no risk of doing something harmful.

Unquoted `rm -rf $XDG_CACHE_HOME` can lead to the same thing as `rm -rf "/some" "path" "with" "spaces"` where the wrong path (`/some/`) is removed (instead of `/some path with spaces/`), if shwordsplit is set for some reason in a user's environment and the XDG_CACHE_HOME variable is set to a path with spaces (less likely) or user's home directory is set to a path with spaces (more likely but very uncommon).

I do realize that meeting all of these conditions is probably unheard of, but given that we don't know what a user might do with their environment nor whether a user might want to put this in a bash script to install powerlevel10k alongside zsh at the same time on a machine where zsh isn't present, say installing zsh via a package manager and powerlevel10k from git, I therefore think it is generally a Good Idea to avoid this type of risk by simply quoting all variables, including the use of `$HOME` as a default value in case XDG_CACHE_HOME itself isn't set (seen when doing `rm -rf ${XDG_CACHE_HOME:-$HOME/.cache}`)

Please let me know your thoughts on whether this will be something you'd consider to merge, or if you have any questions or would like to discuss further, I'm happy to collaborate.

Edit: Fixed wiki style link to github style link and removed an unnecessary backtick from one command to fix formatting of the command.