### PR TITLE
feat: font manual for kmscon

### DIFF
--- a/font.md
+++ b/font.md
@@ -173,6 +173,10 @@ If you are using a different terminal, proceed with manual font installation. ðŸ
      ```text
      font-family = "MesloLGS NF"
      ```
+   - **kmscon**: Add the line `font-name=MesloLGS NF` to `/etc/kmscon/kmscon.conf`. If `MesloLGS` is
+     not rendered correctly, other fonts like `UbuntuMono Nerd Font Mono` or `Hack Nerd Font Mono`
+     might work. Check [this issue](https://github.com/Aetf/kmscon/issues/18) for more information.
+
 1. Run `p10k configure` to generate a new `~/.p10k.zsh`. The old config may work
    incorrectly with the new font.
 

--- a/font.md
+++ b/font.md
@@ -176,7 +176,6 @@ If you are using a different terminal, proceed with manual font installation. ðŸ
    - **kmscon**: Add the line `font-name=MesloLGS NF` to `/etc/kmscon/kmscon.conf`. If `MesloLGS` is
      not rendered correctly, other fonts like `UbuntuMono Nerd Font Mono` or `Hack Nerd Font Mono`
      might work. Check [this issue](https://github.com/Aetf/kmscon/issues/18) for more information.
-
 1. Run `p10k configure` to generate a new `~/.p10k.zsh`. The old config may work
    incorrectly with the new font.
 


### PR DESCRIPTION
Hello everyone,

I would like to add a short manual on how to get the p10k prompt running on the kmscon console.

Unfortunately, `MesloLGS` is not rendered correctly on the kmscon console. Some characters are cut off because they are too large (e.g. the linuxmint logo).

Other fonts, e.g. `Hack Nerd Font Mono` or `UbuntuMono Nerd Font Mono` do not have these issues. See <https://github.com/Aetf/kmscon/issues/18>. (I also added a link to this issue in the code itself)

I leave it to your discretion, if the recommendation for a different font is ok or not. Maybe we should point out that the other fonts are not officially supported.