### PR TITLE
add nixos installation for home-manager and system-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Powerlevel10k.
 - [Arch Linux](#arch-linux)
 - [Alpine Linux](#alpine-linux)
 - [Fig](#fig)
+- [NixOS](#nixos)
 
 ### Manual
 
@@ -548,6 +549,36 @@ ln -s /usr/share/zsh/plugins/powerlevel10k ~/.local/share/zsh/plugins/
 
 Follow the instructions on
 [this page](https://fig.io/plugins/other/powerlevel10k).
+
+### NixOS
+
+**Home Manager**
+```nix
+programs.zsh = {
+  ...
+  plugins = [
+      {
+        name = "zsh-powerlevel10k";
+        src = "${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel10k/";
+        file = "powerlevel10k.zsh-theme";
+      }
+    ];
+
+    initExtra = ''
+      source ~/.p10k.zsh
+    '';
+};
+```
+**System wide**
+```nix
+programs.zsh = {
+  ...
+  promptInit = ''
+    source ${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel10k/powerlevel10k.zsh-theme
+    source ~/.p10k.zsh
+  '';
+};
+```
 
 ## Configuration
 


### PR DESCRIPTION
## Add Installation guide for NixOS to README

Changes:
- A new section in the README.md explaining how to install zsh-powerlevel10k on NixOS.
- Includes necessary configuration steps (Home-Manager, System-Wide).

Reason:
I just took a long time to install zsh-powerlevel10k on my NixOS for just solve problems and figure out the changes and suggestions on NixOS discourse.
So after solving the problem and figuring out how to install it in the system-wide or home manager, I think it will be a good idea for adding the installation guide to README.md.