### PR TITLE
Fix hyperlink for Windows 11

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -2131,7 +2131,12 @@ prompt_dir() {
 
     local content="${(pj.$sep.)parts}"
     if (( _POWERLEVEL9K_DIR_HYPERLINK && _p9k_term_has_href )) && [[ $_p9k__cwd == /* ]]; then
-      _p9k_url_escape $_p9k__cwd
+      local cur_path=$_p9k__cwd
+      if [[ $_p9k_os == Windows && $cur_path != *:* ]]; then
+        # Change /c/current/path to /c:/current/path
+        cur_path="${_p9k__cwd:0:2}:${_p9k__cwd:2}"
+      fi
+      _p9k_url_escape $cur_path
       local header=$'%{\e]8;;file://'$_p9k__ret$'\a%}'
       local footer=$'%{\e]8;;\a%}'
       if (( expand )); then

--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -2134,7 +2134,7 @@ prompt_dir() {
       local cur_path=$_p9k__cwd
       if [[ $_p9k_os == Windows && $cur_path != *:* ]]; then
         # Change /c/current/path to /c:/current/path
-        cur_path="${_p9k__cwd:0:2}:${_p9k__cwd:2}"
+        cur_path="${_p9k__cwd:0:2:u}:${_p9k__cwd:2}"
       fi
       _p9k_url_escape $cur_path
       local header=$'%{\e]8;;file://'$_p9k__ret$'\a%}'


### PR DESCRIPTION
I recently started using p10k on Git Bash on Windows 11 and noticed that I couldn’t click on hyperlinks. It turns out the issue was caused by the links in the header using Unix-style paths (e.g., /c/current/path). So, I created this pull request to handle that case. I hope you’ll consider merging it. Thank you!