### PR TITLE
fix(gcloud): prevent gcloud CLI from hanging

### DIFF
--- a/internal/p10k.zsh
+++ b/internal/p10k.zsh
@@ -4716,7 +4716,9 @@ _p9k_gcloud_prefetch() {
   if ! _p9k_cache_stat_get $0 ${CLOUDSDK_CONFIG:-~/.config/gcloud}/configurations/config_$P9K_GCLOUD_CONFIGURATION; then
     local pair account project_id
     pair="$(gcloud config configurations describe $P9K_GCLOUD_CONFIGURATION \
-      --format=$'value[separator="\1"](properties.core.account,properties.core.project)')"
+      --quiet \
+      --format=$'value[separator="\1"](properties.core.account,properties.core.project)' \
+      </dev/null)"
     (( ! $? )) && IFS=$'\1' read account project_id <<<$pair
     _p9k_cache_stat_set "$account" "$project_id"
   fi


### PR DESCRIPTION
If the `gcloud` command is interactive (e.g. asks to install a component, or needs an update), the current code will hang forever, and is uninterruptible as `INT` is being swallowed.

Fix this with `</dev/null` and `--quiet`.